### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/stackpop/edgezero/security/code-scanning/3](https://github.com/stackpop/edgezero/security/code-scanning/3)

In general, this should be fixed by explicitly restricting the `GITHUB_TOKEN` permissions in the workflow to the minimal scope required. For a formatting/linting workflow that only checks out code and runs tools, `contents: read` at the workflow level is sufficient. If no job needs to modify repository contents, issues, or pull requests, no `write` permissions are needed.

The best fix here without changing existing functionality is to add a top-level `permissions` block that applies to all jobs. This documents that the workflow only needs read access to repository contents and ensures it does not gain broader permissions if repository/organization defaults are changed. Concretely, edit `.github/workflows/format.yml` to insert a `permissions:` section after the `on:` block (lines 3–7) and before `concurrency:` (line 9). The block should be:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or other code are required; this is purely a configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
