### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/stackpop/edgezero/security/code-scanning/2](https://github.com/stackpop/edgezero/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions` block that grants only the minimal required scopes for this workflow. Since this job only needs to read repository contents (for `actions/checkout`) and does not perform any GitHub write operations, `contents: read` is sufficient. This can be applied either at the workflow root (affecting all jobs) or at the `test` job level.

The minimal, non‑behavior‑changing fix here is to add a `permissions` block with `contents: read` at the top level of `.github/workflows/test.yml`, just under the `name:` (or under `on:`) so that it applies to all jobs. No existing steps or behavior need to change. Concretely, in `.github/workflows/test.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `on:` block and the `concurrency:` block (around lines 8–9). No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
