### PR TITLE
Update pr-creator agent with issue linking and no-byline rules

### DIFF
--- a/.claude/agents/pr-creator.md
+++ b/.claude/agents/pr-creator.md
@@ -27,17 +27,24 @@ cargo check --workspace --all-targets --features "fastly cloudflare"
 
 If any gate fails, report the failure and stop — do not create a broken PR.
 
-### 3. Draft PR content
+### 3. Ensure a linked issue exists
+
+Every PR should close a ticket. If no issue exists for this work:
+
+1. Create one using the appropriate issue type (see Issue Types below).
+2. Reference it in the PR body with `Closes #<number>`.
+
+### 4. Draft PR content
 
 Using the `.github/pull_request_template.md` structure, draft:
 
 - **Summary**: 1-3 bullet points describing what the PR does and why.
 - **Changes table**: list each crate/file modified and what changed.
-- **Closes**: link to related issue(s) if mentioned in commits or branch name.
+- **Closes**: `Closes #<issue-number>` to auto-close the linked issue.
 - **Test plan**: check off which verification steps were run.
 - **Checklist**: verify each item applies.
 
-### 4. Create the PR
+### 5. Create the PR
 
 ```
 gh pr create --title "<short title under 70 chars>" --body "$(cat <<'EOF'
@@ -55,9 +62,33 @@ EOF
 )"
 ```
 
-### 5. Report
+### 6. Report
 
 Output the PR URL and a summary of what was included.
+
+## Issue Types
+
+This project uses GitHub issue **types** (not labels) to categorize issues.
+Set the type via GraphQL after creating the issue:
+
+```
+gh api graphql -f query='mutation {
+  updateIssue(input: {
+    id: "<issue_node_id>",
+    issueTypeId: "<type_id>"
+  }) { issue { id title } }
+}'
+```
+
+| Type       | ID                    | Use for                                 |
+| ---------- | --------------------- | --------------------------------------- |
+| Task       | `IT_kwDOAAuvmc4BmvnE` | Technical chores, refactoring, CI, deps |
+| Bug        | `IT_kwDOAAuvmc4BmvnF` | Unexpected behavior or errors           |
+| Story      | `IT_kwDOAAuvmc4BwVyg` | User-facing capability (non-internal)   |
+| Epic       | `IT_kwDOAAuvmc4BwVrF` | Large multi-issue initiatives           |
+| Initiative | `IT_kwDOAAuvmc4BwVrJ` | High-level product/tech/business goals  |
+
+Do **not** use labels as a substitute for types.
 
 ## Rules
 
@@ -67,3 +98,4 @@ Output the PR URL and a summary of what was included.
 - If the branch has many commits, group related changes in the summary.
 - Never force-push or rebase without explicit user approval.
 - Always base PRs against `main` unless told otherwise.
+- Do **not** include any byline, "Generated with" footer, or `Co-Authored-By` trailer ‚Äî in PR bodies or commit messages.


### PR DESCRIPTION
## Summary

- Add a mandatory step to ensure every PR has a linked GitHub issue before creation
- Include issue type reference table with GraphQL IDs for programmatic type assignment
- Enforce no Co-Authored-By trailers or "Generated with" footers in PR bodies or commits

## Changes

| Crate / File | Change |
| ------------ | ------ |
| `.claude/agents/pr-creator.md` | Added step 3 (ensure linked issue), issue types table with GraphQL mutation, and no-byline rule |

## Closes

Closes #181

## Test plan

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No code changes — agent configuration only

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No secrets or credentials committed