### PR TITLE
Fix pr-creator inconsistencies with CLAUDE.md

### DIFF
--- a/.claude/agents/pr-creator.md
+++ b/.claude/agents/pr-creator.md
@@ -25,14 +25,15 @@ cargo test --workspace --all-targets
 cargo check --workspace --all-targets --features "fastly cloudflare"
 ```
 
-If any gate fails, report the failure and stop — do not create a broken PR.
+If any gate fails, report the failure and stop -- do not create a broken PR.
 
 ### 3. Ensure a linked issue exists
 
-Every PR should close a ticket. If no issue exists for this work:
+Every PR should close a ticket.
 
-1. Create one using the appropriate issue type (see Issue Types below).
-2. Reference it in the PR body with `Closes #<number>`.
+1. Ask the user for the issue number to close, or whether to create a new one.
+2. If creating a new issue, use the appropriate issue type (see Issue Types below).
+3. Reference it in the PR body with `Closes #<number>`.
 
 ### 4. Draft PR content
 
@@ -47,7 +48,7 @@ Using the `.github/pull_request_template.md` structure, draft:
 ### 5. Create the PR
 
 ```
-gh pr create --title "<short title under 70 chars>" --body "$(cat <<'EOF'
+gh pr create --title "<short title under 70 chars>" --assignee @me --body "$(cat <<'EOF'
 <filled template>
 EOF
 )"
@@ -98,4 +99,5 @@ Do **not** use labels as a substitute for types.
 - If the branch has many commits, group related changes in the summary.
 - Never force-push or rebase without explicit user approval.
 - Always base PRs against `main` unless told otherwise.
-- Do **not** include any byline, "Generated with" footer, or `Co-Authored-By` trailer ‚Äî in PR bodies or commit messages.
+- Always assign the PR to the current user (`--assignee @me`).
+- Do **not** include any byline, "Generated with" footer, or `Co-Authored-By` trailer -- in PR bodies or commit messages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,3 +318,4 @@ Custom commands live in `.claude/commands/`:
 - Don't make large, sweeping refactors — keep changes minimal and focused.
 - Don't commit without running `cargo test` first.
 - Don't skip `cargo fmt` and `cargo clippy` — CI will reject the PR.
+- Don't include `Co-Authored-By` trailers, "Generated with" footers, or any AI bylines in commits or PR bodies.


### PR DESCRIPTION
## Summary

- Fix mojibake em dashes in pr-creator.md by replacing with ASCII `--` for terminal/editor robustness
- Add no-byline rule to CLAUDE.md "What NOT to Do" so the project source of truth matches the agent convention
- Always assign PRs to the current user via `--assignee @me`
- Ask the user for the issue number before auto-creating one

## Changes

| Crate / File | Change |
| ------------ | ------ |
| `.claude/agents/pr-creator.md` | Fix mojibake `--` (lines 28, 105); add `--assignee @me` to create command and rules; update step 3 to ask user for issue number |
| `CLAUDE.md` | Add no-byline rule to "What NOT to Do" section |

## Closes

Closes #183

## Test plan

- [x] `cargo test --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo check --workspace --all-targets --features "fastly cloudflare"`

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No secrets or credentials committed