### PR TITLE
Add project board integration to agent workflows

### DIFF
--- a/.claude/agents/issue-creator.md
+++ b/.claude/agents/issue-creator.md
@@ -51,7 +51,45 @@ Get the issue node ID with:
 gh issue view <number> --json id --jq '.id'
 ```
 
-### 5. Report
+### 5. Add to project board and set status
+
+Add the issue to the **Stackpop Development** project and set its status to
+"Ready". The `addProjectV2ItemById` mutation returns the project item ID needed
+for the status update.
+
+```
+ITEM_ID=$(gh api graphql -f query='mutation {
+  addProjectV2ItemById(input: {
+    projectId: "PVT_kwDOAAuvmc4BFjF5",
+    contentId: "<issue_node_id>"
+  }) { item { id } }
+}' --jq '.data.addProjectV2ItemById.item.id')
+```
+
+Then set status to "Ready":
+
+```
+gh api graphql -f query='mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "PVT_kwDOAAuvmc4BFjF5",
+    itemId: "'"$ITEM_ID"'",
+    fieldId: "PVTSSF_lADOAAuvmc4BFjF5zg22lrY",
+    value: { singleSelectOptionId: "61e4505c" }
+  }) { projectV2Item { id } }
+}'
+```
+
+Project board status IDs:
+
+| Status      | ID         |
+| ----------- | ---------- |
+| Backlog     | `f75ad846` |
+| Ready       | `61e4505c` |
+| In progress | `47fc9ee4` |
+| In review   | `df73e18b` |
+| Done        | `98236657` |
+
+### 6. Report
 
 Output the issue URL and type.
 

--- a/.claude/agents/pr-creator.md
+++ b/.claude/agents/pr-creator.md
@@ -25,14 +25,15 @@ cargo test --workspace --all-targets
 cargo check --workspace --all-targets --features "fastly cloudflare"
 ```
 
-If any gate fails, report the failure and stop — do not create a broken PR.
+If any gate fails, report the failure and stop -- do not create a broken PR.
 
 ### 3. Ensure a linked issue exists
 
-Every PR should close a ticket. If no issue exists for this work:
+Every PR should close a ticket.
 
-1. Create one using the appropriate issue type (see Issue Types below).
-2. Reference it in the PR body with `Closes #<number>`.
+1. Ask the user for the issue number to close, or whether to create a new one.
+2. If creating a new issue, use the appropriate issue type (see Issue Types below).
+3. Reference it in the PR body with `Closes #<number>`.
 
 ### 4. Draft PR content
 
@@ -47,7 +48,7 @@ Using the `.github/pull_request_template.md` structure, draft:
 ### 5. Create the PR
 
 ```
-gh pr create --title "<short title under 70 chars>" --body "$(cat <<'EOF'
+gh pr create --title "<short title under 70 chars>" --assignee @me --body "$(cat <<'EOF'
 <filled template>
 EOF
 )"
@@ -62,7 +63,68 @@ EOF
 )"
 ```
 
-### 6. Report
+### 6. Update issue status
+
+After creating the PR, move the linked issue to "In progress" on the
+**Stackpop Development** project -- unless it is already "In review".
+
+1. Get the issue's project item ID and current status:
+
+```
+gh api graphql -f query='query($issueId: ID!) {
+  node(id: $issueId) {
+    ... on Issue {
+      projectItems(first: 10) {
+        nodes {
+          id
+          fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name optionId }
+          }
+        }
+      }
+    }
+  }
+}' -f issueId="<issue_node_id>"
+```
+
+2. If the current status is **not** "In review" (`df73e18b`), set it to
+   "In progress" (`47fc9ee4`):
+
+```
+gh api graphql -f query='mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "PVT_kwDOAAuvmc4BFjF5",
+    itemId: "<project_item_id>",
+    fieldId: "PVTSSF_lADOAAuvmc4BFjF5zg22lrY",
+    value: { singleSelectOptionId: "47fc9ee4" }
+  }) { projectV2Item { id } }
+}'
+```
+
+3. If the issue is not yet on the project, add it first:
+
+```
+gh api graphql -f query='mutation {
+  addProjectV2ItemById(input: {
+    projectId: "PVT_kwDOAAuvmc4BFjF5",
+    contentId: "<issue_node_id>"
+  }) { item { id } }
+}'
+```
+
+Then set the status as above.
+
+Project board status IDs:
+
+| Status      | ID         |
+| ----------- | ---------- |
+| Backlog     | `f75ad846` |
+| Ready       | `61e4505c` |
+| In progress | `47fc9ee4` |
+| In review   | `df73e18b` |
+| Done        | `98236657` |
+
+### 7. Report
 
 Output the PR URL and a summary of what was included.
 
@@ -98,4 +160,5 @@ Do **not** use labels as a substitute for types.
 - If the branch has many commits, group related changes in the summary.
 - Never force-push or rebase without explicit user approval.
 - Always base PRs against `main` unless told otherwise.
-- Do **not** include any byline, "Generated with" footer, or `Co-Authored-By` trailer ‚Äî in PR bodies or commit messages.
+- Always assign the PR to the current user (`--assignee @me`).
+- Do **not** include any byline, "Generated with" footer, or `Co-Authored-By` trailer -- in PR bodies or commit messages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,3 +318,4 @@ Custom commands live in `.claude/commands/`:
 - Don't make large, sweeping refactors — keep changes minimal and focused.
 - Don't commit without running `cargo test` first.
 - Don't skip `cargo fmt` and `cargo clippy` — CI will reject the PR.
+- Don't include `Co-Authored-By` trailers, "Generated with" footers, or any AI bylines in commits or PR bodies.


### PR DESCRIPTION
## Summary

- Add project board integration to both agent workflows so issues are properly tracked on the Stackpop Development board
- pr-creator sets linked issues to "In progress" after PR creation (skips if already "In review")
- issue-creator sets new issues to "Ready" after adding to the board (instead of defaulting to "Backlog")
- Both agents now include the full status ID reference table for self-contained operation

## Changes

| Crate / File | Change |
| ------------ | ------ |
| `.claude/agents/pr-creator.md` | Add step 6 with status query/update GraphQL, status ID table, mojibake fix, assignee rule |
| `.claude/agents/issue-creator.md` | Update step 5 to set status to "Ready" after board add, include status ID table |
| `CLAUDE.md` | Add no-byline rule to "What NOT to Do" |

## Closes

Closes #185

## Test plan

- [x] `cargo test --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo check --workspace --all-targets --features "fastly cloudflare"`

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No secrets or credentials committed