### PR TITLE
Fix pr-reviewer agent review body header

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -169,7 +169,7 @@ Include findings that cannot be pinpointed to a single line (cross-cutting
 concerns, architectural issues, dependency problems) in the review body:
 
 ```markdown
-## Staff Engineer Review
+## PR Review
 
 ### Summary
 


### PR DESCRIPTION
## Summary

- Renames the review body header from "Staff Engineer Review" to "PR Review" for a more neutral tone in GitHub review comments

## Changes

| Crate / File | Change |
| ------------ | ------ |
| `.claude/agents/pr-reviewer.md` | Renamed review body template header |

## Closes

Closes #192

## Test plan

- [x] Verified markdown formatting is correct

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No secrets or credentials committed