### PR TITLE
Fix cargo binary install conflicts in CI

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -47,10 +46,7 @@ jobs:
         run: rustup target add wasm32-wasip1 wasm32-unknown-unknown
 
       - name: Setup Viceroy
-        run: |
-          if ! command -v viceroy &>/dev/null; then
-            cargo install viceroy --locked
-          fi
+        run: cargo install viceroy --locked --force
 
       - name: Fetch dependencies (locked)
         run: cargo fetch --locked
@@ -74,7 +70,6 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -114,7 +109,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Install wasm-bindgen test runner
-        run: cargo install wasm-bindgen-cli --version "${{ steps.wasm-bindgen-version.outputs.version }}" --locked
+        run: cargo install wasm-bindgen-cli --version "${{ steps.wasm-bindgen-version.outputs.version }}" --locked --force
 
       - name: Fetch dependencies (locked)
         run: cargo fetch --locked
@@ -137,7 +132,6 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -160,7 +154,7 @@ jobs:
         run: rustup target add wasm32-wasip1
 
       - name: Setup Viceroy
-        run: cargo install viceroy --locked
+        run: cargo install viceroy --locked --force
 
       - name: Fetch dependencies (locked)
         run: cargo fetch --locked


### PR DESCRIPTION
## Summary

- fix CI failures caused by caching `~/.cargo/bin/` and then reinstalling Cargo binaries
- remove the cached Cargo bin directory from workflow caches to avoid stale installed executables
- force the Viceroy install step so repeat installs do not fail when the binary already exists

## Changes

| Crate / File | Change |
| ------------ | ------ |
| `.github/workflows/test.yml` | Removed `~/.cargo/bin/` from the cache path list and changed `cargo install viceroy --locked` to `cargo install viceroy --locked --force` |
| `.github/workflows/format.yml` | Removed `~/.cargo/bin/` from the cache path list |

## Closes

Closes #249

## Test plan

- [ ] `cargo test --workspace --all-targets`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo check --workspace --all-targets --features "fastly cloudflare"`
- [ ] WASM builds: `wasm32-wasip1` (Fastly) / `wasm32-unknown-unknown` (Cloudflare)
- [ ] Manual testing via `edgezero-cli dev`
- [x] Other: reviewed the workflow diff locally; this PR only changes GitHub Actions YAML

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No Tokio deps added to core or adapter crates
- [x] Route params use `{id}` syntax (not `:id`)
- [x] Types imported from `edgezero_core` (not `http` crate)
- [ ] New code has tests
- [x] No secrets or credentials committed
