### PR TITLE
chore: unify workspace package metadata and move to Rust edition 2024

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ scripts/                      # Build/deploy/test helper scripts
 - **Rust**: 1.95.0 (from `.tool-versions`)
 - **Node.js**: 24.12.0 (for docs site only)
 - **Fastly CLI**: 15.1.0
-- **Edition**: 2021
+- **Edition**: 2024
 - **Resolver**: 2
 - **License**: Apache-2.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,11 @@ exclude = ["examples/app-demo"]
 resolver = "2"
 
 [workspace.package]
-edition = "2021"
-version = "0.1.0"
 authors = ["EdgeZero Team <dev@edgezero.dev>"]
+edition = "2021"
 license = "Apache-2.0"
+publish = false
+version = "0.1.0"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,13 @@ resolver = "2"
 authors = ["EdgeZero Team <dev@edgezero.dev>"]
 edition = "2024"
 license = "Apache-2.0"
+# Nothing in CI publishes these crates, so `false` guards against an accidental
+# `cargo publish`. Flipping this to `true` is necessary but not sufficient to
+# release: the internal `edgezero-*` deps are path-only (crates.io requires a
+# `version` on every dependency), and `edgezero-cli`'s optional `demo-example`
+# feature depends on `app-demo-core`, which lives in the excluded
+# `examples/app-demo` workspace and is not published at all. Both need resolving
+# before the first release.
 publish = false
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["EdgeZero Team <dev@edgezero.dev>"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 publish = false
 version = "0.1.0"

--- a/crates/edgezero-adapter-axum/Cargo.toml
+++ b/crates/edgezero-adapter-axum/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "edgezero-adapter-axum"
-edition = { workspace = true }
-version = { workspace = true }
 authors = { workspace = true }
+edition = { workspace = true }
 license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/edgezero-adapter-axum/Cargo.toml
+++ b/crates/edgezero-adapter-axum/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "edgezero-adapter-axum"
+description = "Axum adapter for EdgeZero: native Tokio dev server"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/edgezero-adapter-axum/src/cli.rs
+++ b/crates/edgezero-adapter-axum/src/cli.rs
@@ -11,12 +11,12 @@ use edgezero_adapter::cli_support::{
     find_manifest_upwards, find_workspace_root, path_distance, read_package_name,
 };
 use edgezero_adapter::registry::{
-    register_adapter, Adapter, AdapterAction, AdapterPushContext, ProvisionStores, ReadConfigEntry,
-    ResolvedStoreId,
+    Adapter, AdapterAction, AdapterPushContext, ProvisionStores, ReadConfigEntry, ResolvedStoreId,
+    register_adapter,
 };
 use edgezero_adapter::scaffold::{
-    register_adapter_blueprint, AdapterBlueprint, AdapterFileSpec, CommandTemplates,
-    DependencySpec, LoggingDefaults, ManifestSpec, ReadmeInfo, TemplateRegistration,
+    AdapterBlueprint, AdapterFileSpec, CommandTemplates, DependencySpec, LoggingDefaults,
+    ManifestSpec, ReadmeInfo, TemplateRegistration, register_adapter_blueprint,
 };
 use edgezero_core::addr;
 use edgezero_core::manifest::ManifestLoader;
@@ -63,8 +63,7 @@ static AXUM_DEPENDENCIES: &[DependencySpec] = &[
     DependencySpec {
         key: "dep_edgezero_adapter_axum",
         repo_crate: "crates/edgezero-adapter-axum",
-        fallback:
-            "edgezero-adapter-axum = { git = \"https://git@github.com/stackpop/edgezero.git\", package = \"edgezero-adapter-axum\", default-features = false }",
+        fallback: "edgezero-adapter-axum = { git = \"https://git@github.com/stackpop/edgezero.git\", package = \"edgezero-adapter-axum\", default-features = false }",
         features: &["axum"],
     },
 ];
@@ -1070,9 +1069,11 @@ mod tests {
     fn deploy_returns_error() {
         let result = deploy(&[]);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .contains("does not define a deploy command"));
+        assert!(
+            result
+                .unwrap_err()
+                .contains("does not define a deploy command")
+        );
     }
 
     #[test]

--- a/crates/edgezero-adapter-axum/src/dev_server.rs
+++ b/crates/edgezero-adapter-axum/src/dev_server.rs
@@ -11,7 +11,7 @@ use axum::Router;
 use tokio::net::TcpListener as TokioTcpListener;
 use tokio::runtime::Builder as RuntimeBuilder;
 use tokio::signal;
-use tower::{service_fn, Service as _};
+use tower::{Service as _, service_fn};
 
 use edgezero_core::addr;
 use edgezero_core::app::{Hooks, StoreMetadata, StoresMetadata};
@@ -742,7 +742,7 @@ mod integration_tests {
     use edgezero_core::router::RouterService;
     use edgezero_core::secret_store::SecretHandle as CoreSecretHandle;
     use std::time::{Duration, Instant};
-    use tokio::task::{spawn_blocking, JoinHandle};
+    use tokio::task::{JoinHandle, spawn_blocking};
     use tokio::time::sleep;
 
     struct TestServer {

--- a/crates/edgezero-adapter-axum/src/proxy.rs
+++ b/crates/edgezero-adapter-axum/src/proxy.rs
@@ -6,7 +6,7 @@ use edgezero_core::error::EdgeError;
 use edgezero_core::http::{HeaderName, HeaderValue, Method, StatusCode};
 use edgezero_core::proxy::{ProxyClient, ProxyRequest, ProxyResponse};
 use futures_util::StreamExt as _;
-use reqwest::{header, Client};
+use reqwest::{Client, header};
 
 pub struct AxumProxyClient {
     client: Client,
@@ -124,11 +124,11 @@ mod tests {
 #[cfg(test)]
 mod integration_tests {
     use super::*;
+    use axum::Router;
     use axum::body::Bytes as AxumBytes;
     use axum::http::header::CONTENT_TYPE;
     use axum::http::{HeaderMap as AxumHeaderMap, StatusCode as AxumStatusCode};
     use axum::routing::{delete, get, patch, post, put};
-    use axum::Router;
     use edgezero_core::http::Uri;
     use tokio::net::TcpListener;
 

--- a/crates/edgezero-adapter-axum/src/request.rs
+++ b/crates/edgezero-adapter-axum/src/request.rs
@@ -1,12 +1,12 @@
 use std::net::SocketAddr;
 
-use axum::body::{to_bytes, Body as AxumBody};
+use axum::body::{Body as AxumBody, to_bytes};
 use axum::extract::connect_info::ConnectInfo;
 use axum::http::Request;
 use edgezero_core::body::Body;
-use edgezero_core::http::header::CONTENT_TYPE;
 use edgezero_core::http::HeaderValue;
 use edgezero_core::http::Request as CoreRequest;
+use edgezero_core::http::header::CONTENT_TYPE;
 use edgezero_core::proxy::ProxyHandle;
 
 use crate::context::AxumRequestContext;
@@ -119,10 +119,12 @@ mod tests {
 
         let context = AxumRequestContext::get(&core_request).expect("context");
         assert_eq!(context.remote_addr, Some("127.0.0.1:4000".parse().unwrap()));
-        assert!(core_request
-            .extensions()
-            .get::<ConnectInfo<SocketAddr>>()
-            .is_none());
+        assert!(
+            core_request
+                .extensions()
+                .get::<ConnectInfo<SocketAddr>>()
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/edgezero-adapter-axum/src/response.rs
+++ b/crates/edgezero-adapter-axum/src/response.rs
@@ -2,7 +2,7 @@ use axum::body::Body as AxumBody;
 use axum::http::header::CONTENT_TYPE;
 use axum::http::{HeaderValue, Response, StatusCode};
 use futures::executor::block_on;
-use futures_util::{pin_mut, StreamExt as _};
+use futures_util::{StreamExt as _, pin_mut};
 use tracing::error;
 
 use edgezero_core::body::Body;
@@ -58,7 +58,7 @@ fn error_response_500(message: &'static str) -> Response<AxumBody> {
 mod tests {
     use super::*;
     use edgezero_core::body::Body;
-    use edgezero_core::http::{response_builder, StatusCode};
+    use edgezero_core::http::{StatusCode, response_builder};
     use futures::stream;
 
     #[test]

--- a/crates/edgezero-adapter-axum/src/secret_store.rs
+++ b/crates/edgezero-adapter-axum/src/secret_store.rs
@@ -76,10 +76,11 @@ mod tests {
     });
 
     use super::*;
-    use crate::test_utils::{env_guard, EnvOverride};
+    use crate::test_utils::env_guard;
     use bytes::Bytes;
     use edgezero_core::secret_store::InMemorySecretStore;
     use edgezero_core::secret_store_contract_tests;
+    use edgezero_core::test_env::EnvOverride;
     #[cfg(unix)]
     use std::ffi::OsString;
 
@@ -104,7 +105,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn get_bytes_returns_none_when_var_not_set() {
         let _guard = env_guard().lock().await;
-        let _env = EnvOverride::clear("__EDGEZERO_TEST_MISSING_VAR_XYZ__");
+        let _env = EnvOverride::remove("__EDGEZERO_TEST_MISSING_VAR_XYZ__");
         let store = EnvSecretStore::new();
         let result = store
             .get_bytes("env", "__EDGEZERO_TEST_MISSING_VAR_XYZ__")

--- a/crates/edgezero-adapter-axum/src/service.rs
+++ b/crates/edgezero-adapter-axum/src/service.rs
@@ -220,7 +220,7 @@ mod tests {
     use edgezero_core::config_store::{ConfigStore, ConfigStoreError, ConfigStoreHandle};
     use edgezero_core::context::RequestContext;
     use edgezero_core::error::EdgeError;
-    use edgezero_core::http::{response_builder, StatusCode};
+    use edgezero_core::http::{StatusCode, response_builder};
     use edgezero_core::key_value_store::KvStore;
     use std::sync::Arc;
     use tower::ServiceExt as _;

--- a/crates/edgezero-adapter-axum/src/templates/Cargo.toml.hbs
+++ b/crates/edgezero-adapter-axum/src/templates/Cargo.toml.hbs
@@ -1,5 +1,6 @@
 [package]
 name = "{{proj_axum}}"
+description = "Axum adapter binary for {{name}}"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/edgezero-adapter-axum/src/templates/Cargo.toml.hbs
+++ b/crates/edgezero-adapter-axum/src/templates/Cargo.toml.hbs
@@ -1,8 +1,10 @@
 [package]
 name = "{{proj_axum}}"
-version = "0.1.0"
-edition = "2021"
-publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/edgezero-adapter-axum/src/test_utils.rs
+++ b/crates/edgezero-adapter-axum/src/test_utils.rs
@@ -1,47 +1,12 @@
-use std::env;
-use std::ffi::{OsStr, OsString};
 use std::sync::OnceLock;
 use tokio::sync::Mutex;
-
-/// RAII guard that sets an environment variable for the duration of a test and
-/// restores the original value (or removes the variable) on drop.
-pub struct EnvOverride {
-    key: &'static str,
-    original: Option<OsString>,
-}
-
-impl EnvOverride {
-    #[must_use]
-    #[inline]
-    pub fn clear(key: &'static str) -> Self {
-        let original = env::var_os(key);
-        env::remove_var(key);
-        Self { key, original }
-    }
-
-    #[inline]
-    pub fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-        let original = env::var_os(key);
-        env::set_var(key, value);
-        Self { key, original }
-    }
-}
-
-impl Drop for EnvOverride {
-    #[inline]
-    fn drop(&mut self) {
-        if let Some(original) = &self.original {
-            env::set_var(self.key, original);
-        } else {
-            env::remove_var(self.key);
-        }
-    }
-}
 
 /// Returns a process-wide mutex used to serialize tests that mutate environment variables.
 ///
 /// Both `secret_store` and `service` tests share this lock to avoid data races across
-/// test threads when setting or clearing environment variables.
+/// test threads when setting or clearing environment variables. Hold it for the whole
+/// lifetime of any `edgezero_core::test_env::EnvOverride` — that is the safety contract
+/// the guard relies on.
 #[inline]
 pub fn env_guard() -> &'static Mutex<()> {
     static GUARD: OnceLock<Mutex<()>> = OnceLock::new();

--- a/crates/edgezero-adapter-cloudflare/Cargo.toml
+++ b/crates/edgezero-adapter-cloudflare/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "edgezero-adapter-cloudflare"
-edition = { workspace = true }
-version = { workspace = true }
 authors = { workspace = true }
+edition = { workspace = true }
 license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/edgezero-adapter-cloudflare/Cargo.toml
+++ b/crates/edgezero-adapter-cloudflare/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "edgezero-adapter-cloudflare"
+description = "Cloudflare Workers adapter for EdgeZero"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/edgezero-adapter-cloudflare/src/cli.rs
+++ b/crates/edgezero-adapter-cloudflare/src/cli.rs
@@ -10,12 +10,12 @@ use edgezero_adapter::cli_support::{
     find_manifest_upwards, find_workspace_root, path_distance, read_package_name, run_native_cli,
 };
 use edgezero_adapter::registry::{
-    register_adapter, Adapter, AdapterAction, AdapterPushContext, ProvisionStores, ReadConfigEntry,
-    ResolvedStoreId,
+    Adapter, AdapterAction, AdapterPushContext, ProvisionStores, ReadConfigEntry, ResolvedStoreId,
+    register_adapter,
 };
 use edgezero_adapter::scaffold::{
-    register_adapter_blueprint, AdapterBlueprint, AdapterFileSpec, CommandTemplates,
-    DependencySpec, LoggingDefaults, ManifestSpec, ReadmeInfo, TemplateRegistration,
+    AdapterBlueprint, AdapterFileSpec, CommandTemplates, DependencySpec, LoggingDefaults,
+    ManifestSpec, ReadmeInfo, TemplateRegistration, register_adapter_blueprint,
 };
 use walkdir::WalkDir;
 
@@ -65,15 +65,13 @@ static CLOUDFLARE_DEPENDENCIES: &[DependencySpec] = &[
     DependencySpec {
         key: "dep_edgezero_adapter_cloudflare",
         repo_crate: "crates/edgezero-adapter-cloudflare",
-        fallback:
-            "edgezero-adapter-cloudflare = { git = \"https://git@github.com/stackpop/edgezero.git\", package = \"edgezero-adapter-cloudflare\", default-features = false }",
+        fallback: "edgezero-adapter-cloudflare = { git = \"https://git@github.com/stackpop/edgezero.git\", package = \"edgezero-adapter-cloudflare\", default-features = false }",
         features: &[],
     },
     DependencySpec {
         key: "dep_edgezero_adapter_cloudflare_wasm",
         repo_crate: "crates/edgezero-adapter-cloudflare",
-        fallback:
-            "edgezero-adapter-cloudflare = { git = \"https://git@github.com/stackpop/edgezero.git\", package = \"edgezero-adapter-cloudflare\", default-features = false, features = [\"cloudflare\"] }",
+        fallback: "edgezero-adapter-cloudflare = { git = \"https://git@github.com/stackpop/edgezero.git\", package = \"edgezero-adapter-cloudflare\", default-features = false, features = [\"cloudflare\"] }",
         features: &["cloudflare"],
     },
 ];
@@ -788,7 +786,7 @@ fn item_kind(item: &toml_edit::Item) -> &'static str {
 /// becomes an orphan in the Cloudflare account. `EdgeZero` does not
 /// take a lockfile; operators must serialise provision themselves.
 fn upsert_kv_namespace(path: &Path, binding: &str, id: &str) -> Result<(), String> {
-    use toml_edit::{value, ArrayOfTables, DocumentMut, Item, Table};
+    use toml_edit::{ArrayOfTables, DocumentMut, Item, Table, value};
 
     // Treat NotFound as "start with empty document" symmetrically with
     // `read_namespace_id` so the orphan-namespace hazard goes away: if
@@ -1131,7 +1129,8 @@ pub fn serve(extra_args: &[String]) -> Result<(), String> {
 mod tests {
     use super::*;
     #[cfg(unix)]
-    use std::ffi::OsString;
+    use edgezero_core::test_env::PathPrepend;
+
     #[cfg(unix)]
     use std::sync::Mutex;
     use tempfile::tempdir;
@@ -1147,41 +1146,6 @@ mod tests {
     const TEST_KV_ID_ALT: &str = "cache";
     const TEST_CONFIG_ID: &str = "app_config";
     const TEST_SECRET_ID: &str = "default";
-
-    /// RAII guard: prepends a directory to `$PATH` and restores the original
-    /// value on drop. Mirrors the `PathPrepend` used in `push_cloud.rs`.
-    #[cfg(unix)]
-    struct PathPrepend {
-        original: Option<OsString>,
-    }
-
-    #[cfg(unix)]
-    impl PathPrepend {
-        fn new(extra: &Path) -> Self {
-            let original = env::var_os("PATH");
-            let new = match &original {
-                Some(prev) => {
-                    let mut accum = OsString::from(extra);
-                    accum.push(":");
-                    accum.push(prev);
-                    accum
-                }
-                None => OsString::from(extra),
-            };
-            env::set_var("PATH", new);
-            Self { original }
-        }
-    }
-
-    #[cfg(unix)]
-    impl Drop for PathPrepend {
-        fn drop(&mut self) {
-            match self.original.take() {
-                Some(prev) => env::set_var("PATH", prev),
-                None => env::remove_var("PATH"),
-            }
-        }
-    }
 
     // ---------- extract_namespace_id ----------
 
@@ -1812,8 +1776,7 @@ id = "00112233445566778899aabbccddeeff"
     #[test]
     fn push_dry_run_resolves_namespace_id_and_does_not_invoke_wrangler() {
         let dir = tempdir().expect("tempdir");
-        let original =
-            "name = \"demo\"\n[[kv_namespaces]]\nbinding = \"app_config\"\nid = \"00112233445566778899aabbccddeeff\"\n";
+        let original = "name = \"demo\"\n[[kv_namespaces]]\nbinding = \"app_config\"\nid = \"00112233445566778899aabbccddeeff\"\n";
         let path = write_wrangler(dir.path(), original);
         let entries = vec![
             ("greeting".to_owned(), "hello".to_owned()),

--- a/crates/edgezero-adapter-cloudflare/src/config_store.rs
+++ b/crates/edgezero-adapter-cloudflare/src/config_store.rs
@@ -23,9 +23,9 @@ use std::collections::HashMap;
 #[cfg(not(any(all(feature = "cloudflare", target_arch = "wasm32"), test)))]
 use std::convert::Infallible;
 #[cfg(all(feature = "cloudflare", target_arch = "wasm32"))]
-use worker::kv::KvStore as WorkerKvStore;
-#[cfg(all(feature = "cloudflare", target_arch = "wasm32"))]
 use worker::Env;
+#[cfg(all(feature = "cloudflare", target_arch = "wasm32"))]
+use worker::kv::KvStore as WorkerKvStore;
 
 /// Config store backed by a Cloudflare KV namespace.
 ///

--- a/crates/edgezero-adapter-cloudflare/src/proxy.rs
+++ b/crates/edgezero-adapter-cloudflare/src/proxy.rs
@@ -3,14 +3,14 @@ use bytes::Bytes;
 use edgezero_core::body::Body;
 use edgezero_core::compression::{decode_brotli_stream, decode_gzip_stream};
 use edgezero_core::error::EdgeError;
-use edgezero_core::http::{header, HeaderMap, HeaderName, HeaderValue, Method, StatusCode, Uri};
-use edgezero_core::proxy::{ProxyClient, ProxyRequest, ProxyResponse, PROXY_HEADER};
-use futures_util::stream::{self, LocalBoxStream, StreamExt as _};
+use edgezero_core::http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode, Uri, header};
+use edgezero_core::proxy::{PROXY_HEADER, ProxyClient, ProxyRequest, ProxyResponse};
 use futures_util::TryStreamExt as _;
+use futures_util::stream::{self, LocalBoxStream, StreamExt as _};
 use std::io;
 use worker::{
-    wasm_bindgen::JsValue, Body as WorkerBody, Fetch, Headers, Method as CfMethod,
-    Request as CfRequest, RequestInit, Response as CfResponse,
+    Body as WorkerBody, Fetch, Headers, Method as CfMethod, Request as CfRequest, RequestInit,
+    Response as CfResponse, wasm_bindgen::JsValue,
 };
 
 type ChunkStream = LocalBoxStream<'static, Result<Vec<u8>, io::Error>>;
@@ -153,7 +153,7 @@ fn worker_error_to_io(err: &worker::Error) -> io::Error {
 mod tests {
     use super::*;
     use brotli::CompressorWriter;
-    use flate2::{write::GzEncoder, Compression};
+    use flate2::{Compression, write::GzEncoder};
     use futures::executor::block_on;
     use futures_util::stream;
     use std::io::Write as _;

--- a/crates/edgezero-adapter-cloudflare/src/proxy.rs
+++ b/crates/edgezero-adapter-cloudflare/src/proxy.rs
@@ -93,12 +93,12 @@ fn convert_response(cf_response: &mut CfResponse) -> Result<ProxyResponse, EdgeE
         if name.eq_ignore_ascii_case(header::CONTENT_ENCODING.as_str()) {
             encoding = Some(value.to_ascii_lowercase());
         }
-        if let Ok(header_name) = HeaderName::from_bytes(name.as_bytes()) {
-            if let Ok(header_value) = HeaderValue::from_str(&value) {
-                proxy_response
-                    .headers_mut()
-                    .insert(header_name, header_value);
-            }
+        if let Ok(header_name) = HeaderName::from_bytes(name.as_bytes())
+            && let Ok(header_value) = HeaderValue::from_str(&value)
+        {
+            proxy_response
+                .headers_mut()
+                .insert(header_name, header_value);
         }
     }
 

--- a/crates/edgezero-adapter-cloudflare/src/request.rs
+++ b/crates/edgezero-adapter-cloudflare/src/request.rs
@@ -7,7 +7,7 @@ use edgezero_core::body::Body;
 use edgezero_core::config_store::ConfigStoreHandle;
 use edgezero_core::env_config::EnvConfig;
 use edgezero_core::error::EdgeError;
-use edgezero_core::http::{request_builder, Method as CoreMethod, Request, Uri};
+use edgezero_core::http::{Method as CoreMethod, Request, Uri, request_builder};
 use edgezero_core::key_value_store::KvHandle;
 use edgezero_core::proxy::ProxyHandle;
 use edgezero_core::secret_store::SecretHandle;

--- a/crates/edgezero-adapter-cloudflare/src/templates/Cargo.toml.hbs
+++ b/crates/edgezero-adapter-cloudflare/src/templates/Cargo.toml.hbs
@@ -1,8 +1,10 @@
 [package]
 name = "{{proj_cloudflare}}"
-version = "0.1.0"
-edition = "2021"
-publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/edgezero-adapter-cloudflare/src/templates/Cargo.toml.hbs
+++ b/crates/edgezero-adapter-cloudflare/src/templates/Cargo.toml.hbs
@@ -1,5 +1,6 @@
 [package]
 name = "{{proj_cloudflare}}"
+description = "Cloudflare Workers adapter binary for {{name}}"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/edgezero-adapter-cloudflare/src/templates/src/lib.rs.hbs
+++ b/crates/edgezero-adapter-cloudflare/src/templates/src/lib.rs.hbs
@@ -1,7 +1,7 @@
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
 #[cfg(target_arch = "wasm32")]
-use worker::{event, Context, Env, Request, Response, Result};
+use worker::{Context, Env, Request, Response, Result, event};
 
 /// Entrypoint invoked by Cloudflare Workers.
 ///

--- a/crates/edgezero-adapter-cloudflare/tests/contract.rs
+++ b/crates/edgezero-adapter-cloudflare/tests/contract.rs
@@ -18,14 +18,14 @@ mod tests {
 
     use bytes::Bytes;
     use edgezero_adapter_cloudflare::context::CloudflareRequestContext;
-    use edgezero_adapter_cloudflare::request::{into_core_request, CloudflareService};
+    use edgezero_adapter_cloudflare::request::{CloudflareService, into_core_request};
     use edgezero_adapter_cloudflare::response::from_core_response;
     use edgezero_core::app::App;
     use edgezero_core::body::Body;
     use edgezero_core::config_store::{ConfigStore, ConfigStoreError, ConfigStoreHandle};
     use edgezero_core::context::RequestContext;
     use edgezero_core::error::EdgeError;
-    use edgezero_core::http::{response_builder, Method, Response, StatusCode};
+    use edgezero_core::http::{Method, Response, StatusCode, response_builder};
     use edgezero_core::router::RouterService;
     use futures::stream;
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};

--- a/crates/edgezero-adapter-fastly/Cargo.toml
+++ b/crates/edgezero-adapter-fastly/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "edgezero-adapter-fastly"
+description = "Fastly Compute adapter for EdgeZero"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/edgezero-adapter-fastly/Cargo.toml
+++ b/crates/edgezero-adapter-fastly/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "edgezero-adapter-fastly"
-edition = { workspace = true }
-version = { workspace = true }
 authors = { workspace = true }
+edition = { workspace = true }
 license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/edgezero-adapter-fastly/src/cli.rs
+++ b/crates/edgezero-adapter-fastly/src/cli.rs
@@ -11,12 +11,12 @@ use edgezero_adapter::cli_support::{
     find_manifest_upwards, find_workspace_root, path_distance, read_package_name, run_native_cli,
 };
 use edgezero_adapter::registry::{
-    register_adapter, Adapter, AdapterAction, AdapterPushContext, ProvisionStores, ReadConfigEntry,
-    ResolvedStoreId,
+    Adapter, AdapterAction, AdapterPushContext, ProvisionStores, ReadConfigEntry, ResolvedStoreId,
+    register_adapter,
 };
 use edgezero_adapter::scaffold::{
-    register_adapter_blueprint, AdapterBlueprint, AdapterFileSpec, CommandTemplates,
-    DependencySpec, LoggingDefaults, ManifestSpec, ReadmeInfo, TemplateRegistration,
+    AdapterBlueprint, AdapterFileSpec, CommandTemplates, DependencySpec, LoggingDefaults,
+    ManifestSpec, ReadmeInfo, TemplateRegistration, register_adapter_blueprint,
 };
 use walkdir::WalkDir;
 
@@ -66,15 +66,13 @@ static FASTLY_DEPENDENCIES: &[DependencySpec] = &[
     DependencySpec {
         key: "dep_edgezero_adapter_fastly",
         repo_crate: "crates/edgezero-adapter-fastly",
-        fallback:
-            "edgezero-adapter-fastly = { git = \"https://git@github.com/stackpop/edgezero.git\", package = \"edgezero-adapter-fastly\", default-features = false }",
+        fallback: "edgezero-adapter-fastly = { git = \"https://git@github.com/stackpop/edgezero.git\", package = \"edgezero-adapter-fastly\", default-features = false }",
         features: &[],
     },
     DependencySpec {
         key: "dep_edgezero_adapter_fastly_wasm",
         repo_crate: "crates/edgezero-adapter-fastly",
-        fallback:
-            "edgezero-adapter-fastly = { git = \"https://git@github.com/stackpop/edgezero.git\", package = \"edgezero-adapter-fastly\", default-features = false, features = [\"fastly\"] }",
+        fallback: "edgezero-adapter-fastly = { git = \"https://git@github.com/stackpop/edgezero.git\", package = \"edgezero-adapter-fastly\", default-features = false, features = [\"fastly\"] }",
         features: &["fastly"],
     },
 ];
@@ -117,8 +115,7 @@ static FASTLY_TEMPLATE_REGISTRATIONS: &[TemplateRegistration] = &[
     },
 ];
 
-const FASTLY_INSTALL_HINT: &str =
-    "install the Fastly CLI (https://www.fastly.com/documentation/reference/tools/cli/) and try again";
+const FASTLY_INSTALL_HINT: &str = "install the Fastly CLI (https://www.fastly.com/documentation/reference/tools/cli/) and try again";
 
 struct FastlyCliAdapter;
 
@@ -596,7 +593,7 @@ impl Adapter for FastlyCliAdapter {
         let raw = match fs::read_to_string(&fastly_path) {
             Ok(text) => text,
             Err(err) if err.kind() == ErrorKind::NotFound => {
-                return Ok(ReadConfigEntry::MissingStore)
+                return Ok(ReadConfigEntry::MissingStore);
             }
             Err(err) => {
                 return Err(format!("failed to read {}: {err}", fastly_path.display()));
@@ -879,7 +876,7 @@ fn setup_block_present(path: &Path, kind: &str, id: &str) -> Result<bool, String
 /// server seeding moved to `config push --local` (config-stores
 /// only), so provision only owns the remote / setup half.
 fn append_fastly_setup(path: &Path, kind: &str, id: &str) -> Result<(), String> {
-    use toml_edit::{table, DocumentMut, Item};
+    use toml_edit::{DocumentMut, Item, table};
 
     let raw = match fs::read_to_string(path) {
         Ok(text) => text,
@@ -928,7 +925,7 @@ fn write_fastly_local_config_store(
     platform_name: &str,
     entries: &[(String, String)],
 ) -> Result<(), String> {
-    use toml_edit::{table, DocumentMut, Item, Table, Value};
+    use toml_edit::{DocumentMut, Item, Table, Value, table};
 
     let raw = match fs::read_to_string(path) {
         Ok(text) => text,
@@ -1391,7 +1388,8 @@ mod tests {
     use super::*;
     use edgezero_adapter::cli_support::read_package_name;
     #[cfg(unix)]
-    use std::ffi::OsString;
+    use edgezero_core::test_env::PathPrepend;
+
     #[cfg(unix)]
     use std::sync::Mutex;
     use tempfile::tempdir;
@@ -1405,41 +1403,6 @@ mod tests {
     const TEST_KV_ID: &str = "sessions";
     const TEST_CONFIG_ID: &str = "app_config";
     const TEST_SECRET_ID: &str = "default";
-
-    /// RAII guard: prepends a directory to `$PATH` and restores the original
-    /// value on drop.
-    #[cfg(unix)]
-    struct PathPrepend {
-        original: Option<OsString>,
-    }
-
-    #[cfg(unix)]
-    impl PathPrepend {
-        fn new(extra: &Path) -> Self {
-            let original = env::var_os("PATH");
-            let new_path = match &original {
-                Some(prev) => {
-                    let mut accum = OsString::from(extra);
-                    accum.push(":");
-                    accum.push(prev);
-                    accum
-                }
-                None => OsString::from(extra),
-            };
-            env::set_var("PATH", new_path);
-            Self { original }
-        }
-    }
-
-    #[cfg(unix)]
-    impl Drop for PathPrepend {
-        fn drop(&mut self) {
-            match self.original.take() {
-                Some(prev) => env::set_var("PATH", prev),
-                None => env::remove_var("PATH"),
-            }
-        }
-    }
 
     #[test]
     fn finds_closest_manifest_when_multiple_exist() {

--- a/crates/edgezero-adapter-fastly/src/config_store.rs
+++ b/crates/edgezero-adapter-fastly/src/config_store.rs
@@ -6,8 +6,8 @@ use std::collections::HashMap;
 use crate::chunked_config::resolve_fastly_config_value;
 use async_trait::async_trait;
 use edgezero_core::config_store::{ConfigStore, ConfigStoreError};
-use fastly::config_store::{LookupError, OpenError};
 use fastly::ConfigStore as FastlyConfigStoreInner;
+use fastly::config_store::{LookupError, OpenError};
 
 /// Config store backed by a Fastly Config Store resource link.
 pub struct FastlyConfigStore {
@@ -76,18 +76,18 @@ impl ConfigStore for FastlyConfigStore {
         // transient unavailable. Mapping to `internal` surfaces as HTTP
         // 500 and pushes operators toward `<app-cli> config push` instead
         // of waiting for a 503 to clear.
-        let resolved =
-            resolve_fastly_config_value(key, value, |chunk_key| self.get_sync(chunk_key)).map_err(
-                |err| {
-                    log::warn!(
-                        "Fastly config-store chunk resolution failed for `{key}`: {err}. \
+        let resolved = resolve_fastly_config_value(key, value, |chunk_key| {
+            self.get_sync(chunk_key)
+        })
+        .map_err(|err| {
+            log::warn!(
+                "Fastly config-store chunk resolution failed for `{key}`: {err}. \
                      Re-run `<app-cli> config push` to repair the store."
-                    );
-                    ConfigStoreError::internal(anyhow::anyhow!(
+            );
+            ConfigStoreError::internal(anyhow::anyhow!(
                 "config store entry is corrupt or incomplete; re-run config push to repair: {err}"
             ))
-                },
-            )?;
+        })?;
         Ok(Some(resolved))
     }
 }

--- a/crates/edgezero-adapter-fastly/src/proxy.rs
+++ b/crates/edgezero-adapter-fastly/src/proxy.rs
@@ -4,11 +4,11 @@ use bytes::Bytes;
 use edgezero_core::body::Body;
 use edgezero_core::compression::{decode_brotli_stream, decode_gzip_stream};
 use edgezero_core::error::EdgeError;
-use edgezero_core::http::{header, HeaderMap, HeaderValue, Method, Uri};
-use edgezero_core::proxy::{ProxyClient, ProxyRequest, ProxyResponse, PROXY_HEADER};
+use edgezero_core::http::{HeaderMap, HeaderValue, Method, Uri, header};
+use edgezero_core::proxy::{PROXY_HEADER, ProxyClient, ProxyRequest, ProxyResponse};
 use fastly::{
-    error::anyhow, http::body::StreamingBody, Backend, Request as FastlyRequest,
-    Response as FastlyResponse,
+    Backend, Request as FastlyRequest, Response as FastlyResponse, error::anyhow,
+    http::body::StreamingBody,
 };
 use futures_util::stream::{BoxStream, StreamExt as _};
 use std::io::{self, Write as _};
@@ -210,7 +210,7 @@ fn transform_stream(
 mod tests {
     use super::*;
     use brotli::CompressorWriter;
-    use flate2::{write::GzEncoder, Compression};
+    use flate2::{Compression, write::GzEncoder};
     use futures::executor::block_on;
 
     fn collect_body(body: Body) -> Vec<u8> {

--- a/crates/edgezero-adapter-fastly/src/request.rs
+++ b/crates/edgezero-adapter-fastly/src/request.rs
@@ -8,7 +8,7 @@ use edgezero_core::body::Body;
 use edgezero_core::config_store::ConfigStoreHandle;
 use edgezero_core::env_config::EnvConfig;
 use edgezero_core::error::EdgeError;
-use edgezero_core::http::{request_builder, Extensions, Request};
+use edgezero_core::http::{Extensions, Request, request_builder};
 use edgezero_core::key_value_store::KvHandle;
 use edgezero_core::proxy::ProxyHandle;
 use edgezero_core::secret_store::SecretHandle;
@@ -623,7 +623,7 @@ mod synthesis_tests {
     fn extended_request_extensions_are_visible_to_handler() {
         use edgezero_core::body::Body;
         use edgezero_core::context::RequestContext;
-        use edgezero_core::http::{request_builder, Method, StatusCode};
+        use edgezero_core::http::{Method, StatusCode, request_builder};
         use edgezero_core::router::RouterService;
         use futures::executor::block_on;
 

--- a/crates/edgezero-adapter-fastly/src/templates/Cargo.toml.hbs
+++ b/crates/edgezero-adapter-fastly/src/templates/Cargo.toml.hbs
@@ -1,5 +1,6 @@
 [package]
 name = "{{proj_fastly}}"
+description = "Fastly Compute adapter binary for {{name}}"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/edgezero-adapter-fastly/src/templates/Cargo.toml.hbs
+++ b/crates/edgezero-adapter-fastly/src/templates/Cargo.toml.hbs
@@ -1,8 +1,10 @@
 [package]
 name = "{{proj_fastly}}"
-version = "0.1.0"
-edition = "2021"
-publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/edgezero-adapter-fastly/tests/contract.rs
+++ b/crates/edgezero-adapter-fastly/tests/contract.rs
@@ -16,17 +16,17 @@ mod secret_store_compile_check {
 mod tests {
     use bytes::Bytes;
     use edgezero_adapter_fastly::context::FastlyRequestContext;
-    use edgezero_adapter_fastly::request::{into_core_request, FastlyService};
+    use edgezero_adapter_fastly::request::{FastlyService, into_core_request};
     use edgezero_adapter_fastly::response::from_core_response;
     use edgezero_core::app::App;
     use edgezero_core::body::Body;
     use edgezero_core::config_store::{ConfigStore, ConfigStoreError, ConfigStoreHandle};
     use edgezero_core::context::RequestContext;
     use edgezero_core::error::EdgeError;
-    use edgezero_core::http::{response_builder, Method, Response, StatusCode};
+    use edgezero_core::http::{Method, Response, StatusCode, response_builder};
     use edgezero_core::router::RouterService;
-    use fastly::http::{Method as FastlyMethod, StatusCode as FastlyStatus};
     use fastly::Request as FastlyRequest;
+    use fastly::http::{Method as FastlyMethod, StatusCode as FastlyStatus};
     use futures::stream;
     use std::sync::Arc;
 

--- a/crates/edgezero-adapter-spin/Cargo.toml
+++ b/crates/edgezero-adapter-spin/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "edgezero-adapter-spin"
+description = "Fermyon Spin adapter for EdgeZero"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/edgezero-adapter-spin/Cargo.toml
+++ b/crates/edgezero-adapter-spin/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "edgezero-adapter-spin"
-edition = { workspace = true }
-version = { workspace = true }
 authors = { workspace = true }
+edition = { workspace = true }
 license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/edgezero-adapter-spin/src/cli.rs
+++ b/crates/edgezero-adapter-spin/src/cli.rs
@@ -17,12 +17,12 @@ use edgezero_adapter::cli_support::{
     find_manifest_upwards, find_workspace_root, path_distance, read_package_name, run_native_cli,
 };
 use edgezero_adapter::registry::{
-    register_adapter, Adapter, AdapterAction, AdapterPushContext, ProvisionStores, ReadConfigEntry,
-    ResolvedStoreId, TypedSecretEntry,
+    Adapter, AdapterAction, AdapterPushContext, ProvisionStores, ReadConfigEntry, ResolvedStoreId,
+    TypedSecretEntry, register_adapter,
 };
 use edgezero_adapter::scaffold::{
-    register_adapter_blueprint, AdapterBlueprint, AdapterFileSpec, CommandTemplates,
-    DependencySpec, LoggingDefaults, ManifestSpec, ReadmeInfo, TemplateRegistration,
+    AdapterBlueprint, AdapterFileSpec, CommandTemplates, DependencySpec, LoggingDefaults,
+    ManifestSpec, ReadmeInfo, TemplateRegistration, register_adapter_blueprint,
 };
 use walkdir::WalkDir;
 
@@ -76,15 +76,13 @@ static SPIN_DEPENDENCIES: &[DependencySpec] = &[
     DependencySpec {
         key: "dep_edgezero_adapter_spin",
         repo_crate: "crates/edgezero-adapter-spin",
-        fallback:
-            "edgezero-adapter-spin = { git = \"https://git@github.com/stackpop/edgezero.git\", package = \"edgezero-adapter-spin\", default-features = false }",
+        fallback: "edgezero-adapter-spin = { git = \"https://git@github.com/stackpop/edgezero.git\", package = \"edgezero-adapter-spin\", default-features = false }",
         features: &[],
     },
     DependencySpec {
         key: "dep_edgezero_adapter_spin_wasm",
         repo_crate: "crates/edgezero-adapter-spin",
-        fallback:
-            "edgezero-adapter-spin = { git = \"https://git@github.com/stackpop/edgezero.git\", package = \"edgezero-adapter-spin\", default-features = false, features = [\"spin\"] }",
+        fallback: "edgezero-adapter-spin = { git = \"https://git@github.com/stackpop/edgezero.git\", package = \"edgezero-adapter-spin\", default-features = false, features = [\"spin\"] }",
         features: &["spin"],
     },
 ];
@@ -895,7 +893,7 @@ fn write_sqlite(
 /// - `MissingKey` if the row is absent.
 /// - `Present(value)` on a hit (value decoded from UTF-8 BLOB).
 fn read_sqlite_entry(db_path: &Path, store: &str, key: &str) -> Result<ReadConfigEntry, String> {
-    use rusqlite::{params, Connection, OptionalExtension as _};
+    use rusqlite::{Connection, OptionalExtension as _, params};
 
     if !db_path.exists() {
         return Ok(ReadConfigEntry::MissingStore);
@@ -991,7 +989,7 @@ fn ensure_kv_label_in_component(
     component_id: &str,
     label: &str,
 ) -> Result<bool, String> {
-    use toml_edit::{value, Array, DocumentMut, Value};
+    use toml_edit::{Array, DocumentMut, Value, value};
 
     let raw = fs::read_to_string(spin_path)
         .map_err(|err| format!("failed to read {}: {err}", spin_path.display()))?;
@@ -1638,8 +1636,7 @@ mod tests {
     #[test]
     fn provision_dry_run_does_not_edit_spin_toml() {
         let dir = tempdir().expect("tempdir");
-        let original =
-            "spin_manifest_version = 2\n[application]\nname = \"x\"\nversion = \"0\"\n[component.demo]\nsource = \"demo.wasm\"\n";
+        let original = "spin_manifest_version = 2\n[application]\nname = \"x\"\nversion = \"0\"\n[component.demo]\nsource = \"demo.wasm\"\n";
         let path = write_spin(dir.path(), original);
         let kv_ids: Vec<ResolvedStoreId> =
             ResolvedStoreId::from_logicals(&[TEST_KV_ID, TEST_KV_ID_ALT]);

--- a/crates/edgezero-adapter-spin/src/cli/push_cloud.rs
+++ b/crates/edgezero-adapter-spin/src/cli/push_cloud.rs
@@ -249,9 +249,8 @@ pub(crate) fn write_batch(
 mod tests {
     use super::*;
     #[cfg(unix)]
-    use std::env;
-    #[cfg(unix)]
-    use std::ffi::OsString;
+    use edgezero_core::test_env::PathPrepend;
+
     #[cfg(unix)]
     use std::fs;
     #[cfg(unix)]
@@ -263,7 +262,7 @@ mod tests {
     #[cfg(unix)]
     use std::sync::{Mutex, OnceLock};
     #[cfg(unix)]
-    use tempfile::{tempdir, TempDir};
+    use tempfile::{TempDir, tempdir};
 
     #[test]
     fn detect_fermyon_cloud_from_spin_deploy() {
@@ -469,41 +468,6 @@ exit {exit}
         perms.set_mode(0o755);
         fs::set_permissions(&script_path, perms).expect("chmod +x");
         dir
-    }
-
-    /// RAII guard that prepends a temp dir to `$PATH` and restores
-    /// the prior value on drop.
-    #[cfg(unix)]
-    struct PathPrepend {
-        original: Option<OsString>,
-    }
-
-    #[cfg(unix)]
-    impl PathPrepend {
-        fn new(extra: &StdPath) -> Self {
-            let original = env::var_os("PATH");
-            let new = match &original {
-                Some(prev) => {
-                    let mut accum = OsString::from(extra);
-                    accum.push(":");
-                    accum.push(prev);
-                    accum
-                }
-                None => OsString::from(extra),
-            };
-            env::set_var("PATH", new);
-            Self { original }
-        }
-    }
-
-    #[cfg(unix)]
-    impl Drop for PathPrepend {
-        fn drop(&mut self) {
-            match self.original.take() {
-                Some(prev) => env::set_var("PATH", prev),
-                None => env::remove_var("PATH"),
-            }
-        }
     }
 
     /// A process-wide mutex serialising `PATH`-mutating tests in

--- a/crates/edgezero-adapter-spin/src/cli/push_sqlite.rs
+++ b/crates/edgezero-adapter-spin/src/cli/push_sqlite.rs
@@ -44,7 +44,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 /// Major version range of `spin` CLI / runtime we've verified the
 /// `spin_key_value` schema against. Spin's `crates/key-value-spin`
@@ -222,15 +222,15 @@ pub(crate) fn write_batch(
     // racing `push_cloud`'s fake-spin tests; see its doc comment.
     verify_spin_runtime_compat();
 
-    if let Some(parent) = db_path.parent() {
-        if !parent.as_os_str().is_empty() {
-            fs::create_dir_all(parent).map_err(|err| {
-                format!(
-                    "failed to create parent dir for `{}`: {err}",
-                    db_path.display()
-                )
-            })?;
-        }
+    if let Some(parent) = db_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).map_err(|err| {
+            format!(
+                "failed to create parent dir for `{}`: {err}",
+                db_path.display()
+            )
+        })?;
     }
 
     let mut connection = Connection::open(db_path)

--- a/crates/edgezero-adapter-spin/src/decompress.rs
+++ b/crates/edgezero-adapter-spin/src/decompress.rs
@@ -73,8 +73,8 @@ pub(crate) fn decompress_body(body: Vec<u8>, encoding: Option<&str>) -> Result<V
 #[cfg(test)]
 mod tests {
     use super::*;
-    use flate2::write::GzEncoder;
     use flate2::Compression;
+    use flate2::write::GzEncoder;
     use std::io::Write as _;
 
     #[test]

--- a/crates/edgezero-adapter-spin/src/proxy.rs
+++ b/crates/edgezero-adapter-spin/src/proxy.rs
@@ -4,10 +4,10 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use edgezero_core::body::Body;
 use edgezero_core::error::EdgeError;
-use edgezero_core::http::{header, HeaderValue};
-use edgezero_core::proxy::{ProxyClient, ProxyRequest, ProxyResponse, PROXY_HEADER};
+use edgezero_core::http::{HeaderValue, header};
+use edgezero_core::proxy::{PROXY_HEADER, ProxyClient, ProxyRequest, ProxyResponse};
 use spin_sdk::http::body::IncomingBodyExt as _;
-use spin_sdk::http::{send, FullBody, Request as SpinRequest};
+use spin_sdk::http::{FullBody, Request as SpinRequest, send};
 
 /// A proxy client that uses Spin's outbound HTTP (`spin_sdk::http::send`)
 /// to forward requests to upstream services.

--- a/crates/edgezero-adapter-spin/src/request.rs
+++ b/crates/edgezero-adapter-spin/src/request.rs
@@ -3,27 +3,27 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 
+use crate::SpinFullResponse;
 use crate::config_store::SpinConfigStore;
-use crate::context::{parse_client_addr, SpinRequestContext};
-use crate::key_value_store::{SpinKvStore, DEFAULT_MAX_LIST_KEYS};
+use crate::context::{SpinRequestContext, parse_client_addr};
+use crate::key_value_store::{DEFAULT_MAX_LIST_KEYS, SpinKvStore};
 use crate::proxy::SpinProxyClient;
 use crate::response::from_core_response;
 use crate::secret_store::SpinSecretStore;
-use crate::SpinFullResponse;
 use edgezero_core::app::{App, StoreMetadata};
 use edgezero_core::body::Body;
 use edgezero_core::config_store::ConfigStoreHandle;
 use edgezero_core::env_config::EnvConfig;
 use edgezero_core::error::EdgeError;
-use edgezero_core::http::{request_builder, Request};
+use edgezero_core::http::{Request, request_builder};
 use edgezero_core::key_value_store::KvHandle;
 use edgezero_core::proxy::ProxyHandle;
 use edgezero_core::secret_store::SecretHandle;
 use edgezero_core::store_registry::{
     BoundSecretStore, ConfigRegistry, ConfigStoreBinding, KvRegistry, SecretRegistry, StoreRegistry,
 };
-use spin_sdk::http::body::IncomingBodyExt as _;
 use spin_sdk::http::Request as SpinRequest;
+use spin_sdk::http::body::IncomingBodyExt as _;
 
 /// Per-dispatch store wiring assembled before the request enters the router.
 /// The struct itself is `pub(crate)` because `dispatch_with_handles` takes it

--- a/crates/edgezero-adapter-spin/src/templates/Cargo.toml.hbs
+++ b/crates/edgezero-adapter-spin/src/templates/Cargo.toml.hbs
@@ -1,8 +1,10 @@
 [package]
 name = "{{proj_spin}}"
-version = "0.1.0"
-edition = "2021"
-publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/edgezero-adapter-spin/src/templates/Cargo.toml.hbs
+++ b/crates/edgezero-adapter-spin/src/templates/Cargo.toml.hbs
@@ -1,5 +1,6 @@
 [package]
 name = "{{proj_spin}}"
+description = "Fermyon Spin adapter binary for {{name}}"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/edgezero-adapter-spin/tests/contract.rs
+++ b/crates/edgezero-adapter-spin/tests/contract.rs
@@ -110,7 +110,7 @@ mod tests {
     use edgezero_core::config_store::{ConfigStore, ConfigStoreError, ConfigStoreHandle};
     use edgezero_core::context::RequestContext;
     use edgezero_core::error::EdgeError;
-    use edgezero_core::http::{request_builder, response_builder, Response, StatusCode};
+    use edgezero_core::http::{Response, StatusCode, request_builder, response_builder};
     use edgezero_core::key_value_store::{KvError, KvHandle, KvPage, KvStore};
     use edgezero_core::router::RouterService;
     use edgezero_core::secret_store::{SecretError, SecretHandle, SecretStore};

--- a/crates/edgezero-adapter/Cargo.toml
+++ b/crates/edgezero-adapter/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "edgezero-adapter"
-version = "0.1.0"
-edition = "2021"
-license = { workspace = true }
 description = "Adapter registry and traits for EdgeZero adapters"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/edgezero-cli/Cargo.toml
+++ b/crates/edgezero-cli/Cargo.toml
@@ -47,6 +47,7 @@ walkdir = { workspace = true, optional = true }
 toml = { workspace = true }
 
 [dev-dependencies]
+edgezero-core = { workspace = true, features = ["test-utils"] }
 tempfile = { workspace = true }
 
 [features]

--- a/crates/edgezero-cli/Cargo.toml
+++ b/crates/edgezero-cli/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "edgezero-cli"
-version = "0.1.0"
-edition = "2021"
-license = { workspace = true }
 description = "EdgeZero CLI: build and deploy to multiple edge adapters"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/edgezero-cli/src/adapter.rs
+++ b/crates/edgezero-cli/src/adapter.rs
@@ -94,21 +94,21 @@ pub fn execute(
     manifest_loader: Option<&ManifestLoader>,
     adapter_args: &[String],
 ) -> Result<(), String> {
-    if let Some(loader) = manifest_loader {
-        if let Some(command) = manifest_command(loader.manifest(), adapter_name, action) {
-            let root = loader.manifest().root().unwrap_or_else(|| Path::new("."));
-            let env = loader.manifest().environment_for(adapter_name);
-            let adapter_bind = adapter_bind_from_manifest(loader.manifest(), adapter_name);
-            return run_shell(
-                command,
-                root,
-                adapter_name,
-                action,
-                Some(env),
-                adapter_bind,
-                adapter_args,
-            );
-        }
+    if let Some(loader) = manifest_loader
+        && let Some(command) = manifest_command(loader.manifest(), adapter_name, action)
+    {
+        let root = loader.manifest().root().unwrap_or_else(|| Path::new("."));
+        let env = loader.manifest().environment_for(adapter_name);
+        let adapter_bind = adapter_bind_from_manifest(loader.manifest(), adapter_name);
+        return run_shell(
+            command,
+            root,
+            adapter_name,
+            action,
+            Some(env),
+            adapter_bind,
+            adapter_args,
+        );
     }
 
     let adapter = adapter_registry::get_adapter(adapter_name).ok_or_else(|| {
@@ -206,15 +206,15 @@ fn run_shell(
     // when the parent env already has the canonical variable so the
     // user's CLI-invocation override wins over everything.
     let (manifest_host, manifest_port) = adapter_bind;
-    if let Some(host) = manifest_host {
-        if env::var_os("EDGEZERO__ADAPTER__HOST").is_none() {
-            cmd.env("EDGEZERO__ADAPTER__HOST", host);
-        }
+    if let Some(host) = manifest_host
+        && env::var_os("EDGEZERO__ADAPTER__HOST").is_none()
+    {
+        cmd.env("EDGEZERO__ADAPTER__HOST", host);
     }
-    if let Some(port) = manifest_port {
-        if env::var_os("EDGEZERO__ADAPTER__PORT").is_none() {
-            cmd.env("EDGEZERO__ADAPTER__PORT", port.to_string());
-        }
+    if let Some(port) = manifest_port
+        && env::var_os("EDGEZERO__ADAPTER__PORT").is_none()
+    {
+        cmd.env("EDGEZERO__ADAPTER__PORT", port.to_string());
     }
 
     if let Some(env) = environment {
@@ -256,14 +256,17 @@ fn shell_join(args: &[String]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_environment, ResolvedEnvironment};
+    use super::{ResolvedEnvironment, apply_environment};
+    use crate::test_support::manifest_guard;
     use edgezero_core::manifest::ResolvedEnvironmentBinding;
-    use std::env;
+    use edgezero_core::test_env::EnvOverride;
     use std::process::Command;
 
     #[test]
     fn apply_environment_sets_defaults_and_checks_secrets() {
-        env::remove_var("EDGEZERO_TEST_SECRET");
+        let _lock = manifest_guard().lock().expect("env lock");
+        // Unset for the missing-secret path; restores the parent value on drop.
+        let _unset = EnvOverride::remove("EDGEZERO_TEST_SECRET");
 
         let env = ResolvedEnvironment {
             secrets: vec![ResolvedEnvironmentBinding {
@@ -285,7 +288,7 @@ mod tests {
         let result = apply_environment(adapter_name, &env, &mut Command::new("echo"));
         assert!(result.is_err());
 
-        env::set_var("EDGEZERO_TEST_SECRET", "set");
+        let _secret = EnvOverride::set("EDGEZERO_TEST_SECRET", "set");
         let mut cmd = Command::new("echo");
         apply_environment(adapter_name, &env, &mut cmd).expect("environment applied");
         let has_var = cmd.get_envs().any(|(key, value)| {
@@ -293,8 +296,6 @@ mod tests {
                 && value.and_then(|val| val.to_str()) == Some("https://demo")
         });
         assert!(has_var);
-
-        env::remove_var("EDGEZERO_TEST_SECRET");
     }
 
     #[test]
@@ -307,7 +308,8 @@ mod tests {
         // would inject the manifest value and the parent override
         // would be lost.
         const KEY: &str = "EDGEZERO_TEST_PARENT_WINS";
-        env::set_var(KEY, "from_parent_shell");
+        let _lock = manifest_guard().lock().expect("env lock");
+        let _parent = EnvOverride::set(KEY, "from_parent_shell");
 
         let env = ResolvedEnvironment {
             secrets: vec![],
@@ -333,8 +335,6 @@ mod tests {
             "manifest default must NOT be injected when parent env is already set; \
              parent value would otherwise be shadowed"
         );
-
-        env::remove_var(KEY);
     }
 
     #[test]
@@ -342,7 +342,8 @@ mod tests {
         // Mirror of the above: when the parent shell has NOT set the
         // env var, the manifest default fills it in.
         const KEY: &str = "EDGEZERO_TEST_MANIFEST_FILLS";
-        env::remove_var(KEY);
+        let _lock = manifest_guard().lock().expect("env lock");
+        let _unset = EnvOverride::remove(KEY);
 
         let env = ResolvedEnvironment {
             secrets: vec![],

--- a/crates/edgezero-cli/src/auth.rs
+++ b/crates/edgezero-cli/src/auth.rs
@@ -36,7 +36,7 @@ pub fn run_auth(args: &AuthArgs) -> Result<(), String> {
 mod tests {
     use super::*;
     use crate::args::{AuthArgs, AuthSub};
-    use crate::test_support::{manifest_guard, EnvOverride, BASIC_MANIFEST};
+    use crate::test_support::{BASIC_MANIFEST, EnvOverride, manifest_guard};
     use std::fs;
     use tempfile::TempDir;
 

--- a/crates/edgezero-cli/src/bin/check_no_nested_app_config.rs
+++ b/crates/edgezero-cli/src/bin/check_no_nested_app_config.rs
@@ -56,7 +56,7 @@ use std::string::ToString;
 use proc_macro2::{Ident, Span};
 use syn::punctuated::Punctuated;
 use syn::visit::Visit;
-use syn::{visit, GenericArgument, PathArguments, Token, Type};
+use syn::{GenericArgument, PathArguments, Token, Type, visit};
 use walkdir::WalkDir;
 
 // ---------------------------------------------------------------------------
@@ -233,10 +233,10 @@ fn type_contains_app_config_struct(ty: &Type, set: &HashSet<String>) -> Option<S
             if matches!(ident.as_str(), "Option" | "Vec" | "Box" | "Rc" | "Arc") {
                 if let PathArguments::AngleBracketed(ab) = &last.arguments {
                     for arg in &ab.args {
-                        if let GenericArgument::Type(inner) = arg {
-                            if let Some(found) = type_contains_app_config_struct(inner, set) {
-                                return Some(found);
-                            }
+                        if let GenericArgument::Type(inner) = arg
+                            && let Some(found) = type_contains_app_config_struct(inner, set)
+                        {
+                            return Some(found);
                         }
                     }
                 }

--- a/crates/edgezero-cli/src/config.rs
+++ b/crates/edgezero-cli/src/config.rs
@@ -31,14 +31,14 @@ use edgezero_core::app_config::{
 use edgezero_core::blob_envelope::BlobEnvelope;
 use edgezero_core::env_config::EnvConfig;
 use edgezero_core::manifest::{Manifest, ManifestLoader, StoreDeclaration};
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use similar::TextDiff;
 use std::collections::BTreeMap;
-use std::io::{stdin, Error as IoError, IsTerminal as _, Write};
+use std::io::{Error as IoError, IsTerminal as _, Write, stdin};
 use std::path::{Path, PathBuf};
-use toml::value::Table;
 use toml::Value;
+use toml::value::Table;
 use validator::Validate;
 
 /// Pre-loaded state for either push flow. Shares
@@ -1292,12 +1292,11 @@ pub(crate) fn reject_merged_id_collisions(
             let platform = env_config.store_name(kind, id);
             if let Some((prior_kind, prior_id)) =
                 seen_platform.insert(platform.clone(), (kind, id.clone()))
+                && (prior_kind != *kind || prior_id != *id)
             {
-                if prior_kind != *kind || prior_id != *id {
-                    return Err(format!(
-                        "stores `[stores.{prior_kind}].{prior_id}` and `[stores.{kind}].{id}` both resolve to platform label `{platform}` (via the `EDGEZERO__STORES__<KIND>__<ID>__NAME` overlay or matching logical-id default), but adapter `{adapter_name}` backs those kinds with the same runtime store. Renaming one of the env overrides (or removing them so the logical ids stay distinct) fixes this -- both writes currently land on the same `key_value_stores` label.",
-                    ));
-                }
+                return Err(format!(
+                    "stores `[stores.{prior_kind}].{prior_id}` and `[stores.{kind}].{id}` both resolve to platform label `{platform}` (via the `EDGEZERO__STORES__<KIND>__<ID>__NAME` overlay or matching logical-id default), but adapter `{adapter_name}` backs those kinds with the same runtime store. Renaming one of the env overrides (or removing them so the logical ids stay distinct) fixes this -- both writes currently land on the same `key_value_stores` label.",
+                ));
             }
         }
     }
@@ -1630,11 +1629,12 @@ fn format_app_config_error(err: &AppConfigError) -> String {
 )]
 mod tests {
     use super::*;
-    use crate::test_support::{manifest_guard, EnvOverride};
+    use crate::test_support::{EnvOverride, manifest_guard};
+    #[cfg(unix)]
+    use edgezero_core::test_env::PathPrepend;
     use serde::{Deserialize, Serialize};
     use std::borrow::Cow;
-    #[cfg(unix)]
-    use std::ffi::OsString;
+
     use std::fs;
     #[cfg(unix)]
     use std::sync::Mutex;
@@ -3318,44 +3318,6 @@ ids = ["default"]
     // the Fermyon Cloud detection path inside `read_config_entry`.
 
     // --- PATH-mutation helpers (mirrors Cloudflare adapter test pattern) ---
-
-    /// RAII guard: prepends `extra` to `$PATH` and restores the original
-    /// value on drop. Serialise with [`path_mutation_guard`] so parallel
-    /// tests don't race on PATH.
-    #[cfg(unix)]
-    struct PathPrepend {
-        original: Option<OsString>,
-    }
-
-    #[cfg(unix)]
-    impl PathPrepend {
-        fn new(extra: &Path) -> Self {
-            use std::env;
-            let original = env::var_os("PATH");
-            let new_path = match &original {
-                Some(prev) => {
-                    let mut acc = OsString::from(extra);
-                    acc.push(":");
-                    acc.push(prev);
-                    acc
-                }
-                None => OsString::from(extra),
-            };
-            env::set_var("PATH", new_path);
-            Self { original }
-        }
-    }
-
-    #[cfg(unix)]
-    impl Drop for PathPrepend {
-        fn drop(&mut self) {
-            use std::env;
-            match self.original.take() {
-                Some(prev) => env::set_var("PATH", prev),
-                None => env::remove_var("PATH"),
-            }
-        }
-    }
 
     /// Process-wide mutex serialising PATH-mutating tests so parallel
     /// test threads don't race on the `$PATH` environment variable.

--- a/crates/edgezero-cli/src/diff.rs
+++ b/crates/edgezero-cli/src/diff.rs
@@ -502,10 +502,10 @@ mod tests {
         let changes = collect_changes(&remote, &local);
         let mut added: BTreeMap<String, serde_json::Value> = BTreeMap::new();
         for entry in changes {
-            if matches!(entry.kind, DiffKind::Added) {
-                if let Some(val) = entry.to {
-                    added.insert(entry.path, val);
-                }
+            if matches!(entry.kind, DiffKind::Added)
+                && let Some(val) = entry.to
+            {
+                added.insert(entry.path, val);
             }
         }
         assert_eq!(

--- a/crates/edgezero-cli/src/generator.rs
+++ b/crates/edgezero-cli/src/generator.rs
@@ -1168,6 +1168,76 @@ mod tests {
         assert!(gitignore.contains("target/"));
         let clippy = fs::read_to_string(project_dir.join("clippy.toml")).expect("read clippy.toml");
         assert!(clippy.contains("allow-expect-in-tests = true"));
+
+        // The generated manifests must keep the package-metadata contract: the
+        // root declares the five shared fields once, and EVERY member inherits
+        // all five rather than hardcoding them. Asserted structurally (not with
+        // `contains`) so template drift cannot silently reintroduce a crate that
+        // pins its own `version`/`edition` or drops `publish`.
+        let root: toml::Value = toml::from_str(&cargo_toml).expect("parse root Cargo.toml");
+        let shared = root
+            .get("workspace")
+            .and_then(|ws| ws.get("package"))
+            .expect("root [workspace.package]");
+        assert_eq!(
+            shared.get("edition").and_then(toml::Value::as_str),
+            Some("2024"),
+            "generated workspace must pin the Rust edition"
+        );
+        assert_eq!(
+            shared.get("publish").and_then(toml::Value::as_bool),
+            Some(false),
+            "generated crates must not be publishable by default"
+        );
+        assert_eq!(
+            shared.get("version").and_then(toml::Value::as_str),
+            Some("0.1.0")
+        );
+        assert_eq!(
+            shared.get("license").and_then(toml::Value::as_str),
+            Some("Apache-2.0")
+        );
+        assert!(
+            shared
+                .get("authors")
+                .and_then(toml::Value::as_array)
+                .is_some(),
+            "root [workspace.package] must declare authors"
+        );
+
+        let members: Vec<PathBuf> = fs::read_dir(project_dir.join("crates"))
+            .expect("read crates dir")
+            .map(|entry| entry.expect("crate dir entry").path())
+            .collect();
+        assert!(
+            members.len() >= 2,
+            "expected at least the generated core and cli crates"
+        );
+        for dir in members {
+            let raw = fs::read_to_string(dir.join("Cargo.toml")).expect("read member Cargo.toml");
+            let parsed: toml::Value = toml::from_str(&raw).expect("parse member Cargo.toml");
+            let package = parsed.get("package").expect("member [package]");
+            let label = dir.display();
+
+            for field in ["authors", "edition", "license", "publish", "version"] {
+                let inherited = package
+                    .get(field)
+                    .and_then(|value| value.get("workspace"))
+                    .and_then(toml::Value::as_bool);
+                assert_eq!(
+                    inherited,
+                    Some(true),
+                    "{label}: `{field}` must be inherited via {{ workspace = true }}"
+                );
+            }
+            for field in ["name", "description"] {
+                let value = package.get(field).and_then(toml::Value::as_str);
+                assert!(
+                    value.is_some_and(|found| !found.trim().is_empty()),
+                    "{label}: `{field}` must be present and non-empty"
+                );
+            }
+        }
     }
 
     fn assert_scaffold_crate_lints(project_dir: &Path) {

--- a/crates/edgezero-cli/src/generator.rs
+++ b/crates/edgezero-cli/src/generator.rs
@@ -1,7 +1,7 @@
 use crate::args::NewArgs;
 use crate::scaffold::{
-    register_templates, resolve_dep_line, sanitize_crate_name, write_tmpl, ResolvedDependency,
-    ScaffoldError,
+    ResolvedDependency, ScaffoldError, register_templates, resolve_dep_line, sanitize_crate_name,
+    write_tmpl,
 };
 use edgezero_adapter::scaffold;
 use edgezero_adapter::scaffold::AdapterBlueprint;
@@ -806,39 +806,12 @@ fn initialize_git_repo(out_dir: &Path) {
 mod tests {
     use super::*;
     use edgezero_core::app_config::app_name_prefix;
+    use edgezero_core::test_env::PathPrepend as PathOverride;
     use std::path::Path;
     use tempfile::TempDir;
 
     // `super::*` re-exports `env` and `fs` from outer `use` lines, so they're
     // already in scope here.
-
-    struct PathOverride {
-        original: Option<String>,
-    }
-
-    impl PathOverride {
-        fn prepend(path: &Path) -> Self {
-            let original = env::var("PATH").ok();
-            let sep = if cfg!(windows) { ";" } else { ":" };
-            let prefix = path.to_string_lossy();
-            let new_path = match &original {
-                Some(existing) if !existing.is_empty() => format!("{prefix}{sep}{existing}"),
-                _ => prefix.into_owned(),
-            };
-            env::set_var("PATH", &new_path);
-            Self { original }
-        }
-    }
-
-    impl Drop for PathOverride {
-        fn drop(&mut self) {
-            if let Some(original) = &self.original {
-                env::set_var("PATH", original);
-            } else {
-                env::remove_var("PATH");
-            }
-        }
-    }
 
     #[test]
     fn upper_camel_from_sanitized_covers_derivation_rules() {
@@ -1012,9 +985,10 @@ mod tests {
         // string carries the underlying error.
         let err: GeneratorError = fmt::Error.into();
         assert!(matches!(err, GeneratorError::Format(_)));
-        assert!(err
-            .to_string()
-            .contains("failed to format generator output"));
+        assert!(
+            err.to_string()
+                .contains("failed to format generator output")
+        );
     }
 
     fn write_git_stub(bin_dir: &Path) {
@@ -1260,7 +1234,7 @@ mod tests {
         let temp = TempDir::new().expect("temp dir");
         let bin_dir = temp.path().join("bin");
         write_git_stub(&bin_dir);
-        let _path_guard = PathOverride::prepend(&bin_dir);
+        let _path_guard = PathOverride::new(&bin_dir);
 
         let args = NewArgs {
             name: "demo-app".into(),

--- a/crates/edgezero-cli/src/lib.rs
+++ b/crates/edgezero-cli/src/lib.rs
@@ -48,8 +48,8 @@ pub mod args;
 pub use auth::run_auth;
 #[cfg(feature = "cli")]
 pub use config::{
-    run_config_diff_typed, run_config_push, run_config_push_typed, run_config_validate,
-    run_config_validate_typed, DiffExit,
+    DiffExit, run_config_diff_typed, run_config_push, run_config_push_typed, run_config_validate,
+    run_config_validate_typed,
 };
 #[cfg(feature = "cli")]
 pub use provision::run_provision;
@@ -225,9 +225,15 @@ fn store_bindings_message(adapter_name: &str, manifest: &ManifestLoader) -> Opti
     // metadata from secret material), and adapters/operators can read the
     // binding name from their own `edgezero.toml` if they need to verify it.
     let message = match adapter_name {
-        "axum" => "[edgezero] secrets enabled for axum -- ensure the required environment variables are set for local runs",
-        "cloudflare" => "[edgezero] secrets enabled for cloudflare -- ensure the required secret bindings exist in wrangler",
-        _ => "[edgezero] secrets enabled -- ensure the configured secret store is provisioned on the target platform",
+        "axum" => {
+            "[edgezero] secrets enabled for axum -- ensure the required environment variables are set for local runs"
+        }
+        "cloudflare" => {
+            "[edgezero] secrets enabled for cloudflare -- ensure the required secret bindings exist in wrangler"
+        }
+        _ => {
+            "[edgezero] secrets enabled -- ensure the configured secret store is provisioned on the target platform"
+        }
     };
 
     Some(message.to_owned())
@@ -288,7 +294,7 @@ fn load_manifest_optional() -> Result<Option<ManifestLoader>, String> {
 #[cfg(feature = "cli")]
 mod tests {
     use super::*;
-    use crate::test_support::{manifest_guard, EnvOverride, BASIC_MANIFEST};
+    use crate::test_support::{BASIC_MANIFEST, EnvOverride, manifest_guard};
     use edgezero_core::manifest::ManifestLoader;
     use std::fs;
     use tempfile::TempDir;

--- a/crates/edgezero-cli/src/provision.rs
+++ b/crates/edgezero-cli/src/provision.rs
@@ -151,7 +151,7 @@ fn resolve_kind(
 mod tests {
     use super::*;
     use crate::args::ProvisionArgs;
-    use crate::test_support::{manifest_guard, EnvOverride, PROVISION_MANIFEST};
+    use crate::test_support::{EnvOverride, PROVISION_MANIFEST, manifest_guard};
     use std::fs;
     use tempfile::TempDir;
 

--- a/crates/edgezero-cli/src/templates/cli/Cargo.toml.hbs
+++ b/crates/edgezero-cli/src/templates/cli/Cargo.toml.hbs
@@ -1,8 +1,10 @@
 [package]
 name = "{{proj_cli}}"
-version = "0.1.0"
-edition = "2021"
-publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/edgezero-cli/src/templates/cli/Cargo.toml.hbs
+++ b/crates/edgezero-cli/src/templates/cli/Cargo.toml.hbs
@@ -1,5 +1,6 @@
 [package]
 name = "{{proj_cli}}"
+description = "CLI entry point for {{name}}"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/edgezero-cli/src/templates/cli/src/main.rs.hbs
+++ b/crates/edgezero-cli/src/templates/cli/src/main.rs.hbs
@@ -11,11 +11,11 @@
 //! checks, and the Spin namespace collision check all run.
 
 use clap::{Parser, Subcommand};
+use edgezero_cli::DiffExit;
 use edgezero_cli::args::{
     AuthArgs, BuildArgs, ConfigDiffArgs, ConfigPushArgs, ConfigValidateArgs, DeployArgs, NewArgs,
     ProvisionArgs, ServeArgs,
 };
-use edgezero_cli::DiffExit;
 use {{proj_core_mod}}::config::{{NameUpperCamel}}Config;
 
 #[derive(Parser, Debug)]

--- a/crates/edgezero-cli/src/templates/core/Cargo.toml.hbs
+++ b/crates/edgezero-cli/src/templates/core/Cargo.toml.hbs
@@ -1,8 +1,10 @@
 [package]
 name = "{{proj_core}}"
-version = "0.1.0"
-edition = "2021"
-publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/edgezero-cli/src/templates/core/Cargo.toml.hbs
+++ b/crates/edgezero-cli/src/templates/core/Cargo.toml.hbs
@@ -22,4 +22,7 @@ validator = { workspace = true }
 
 [dev-dependencies]
 async-trait = "0.1"
+# `test-utils` exposes `edgezero_core::test_env`, the shared RAII env guards the
+# handler tests below use to override `API_BASE_URL` without racing each other.
+edgezero-core = { workspace = true, features = ["test-utils"] }
 serde_json = "1"

--- a/crates/edgezero-cli/src/templates/core/Cargo.toml.hbs
+++ b/crates/edgezero-cli/src/templates/core/Cargo.toml.hbs
@@ -1,5 +1,6 @@
 [package]
 name = "{{proj_core}}"
+description = "Core handlers and configuration for {{name}}"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/edgezero-cli/src/templates/core/src/handlers.rs.hbs
+++ b/crates/edgezero-cli/src/templates/core/src/handlers.rs.hbs
@@ -7,7 +7,7 @@ use edgezero_core::extractor::{Headers, Json, Path};
 use edgezero_core::http::{self, Response, StatusCode, Uri};
 use edgezero_core::proxy::ProxyRequest;
 use edgezero_core::response::Text;
-use futures::{stream, StreamExt as _};
+use futures::{StreamExt as _, stream};
 use std::env;
 
 const DEFAULT_PROXY_BASE: &str = "https://httpbin.org";
@@ -89,11 +89,11 @@ fn build_proxy_target(rest: &str, original_uri: &Uri) -> Result<Uri, EdgeError> 
         target.push_str(trimmed_rest);
     }
 
-    if let Some(query) = original_uri.query() {
-        if !query.is_empty() {
-            target.push('?');
-            target.push_str(query);
-        }
+    if let Some(query) = original_uri.query()
+        && !query.is_empty()
+    {
+        target.push('?');
+        target.push_str(query);
     }
 
     target
@@ -136,14 +136,13 @@ mod tests {
     use edgezero_core::body::Body;
     use edgezero_core::context::RequestContext;
     use edgezero_core::http::header::{HeaderName, HeaderValue};
-    use edgezero_core::http::{request_builder, Method, StatusCode, Uri};
+    use edgezero_core::http::{Method, StatusCode, Uri, request_builder};
     use edgezero_core::params::PathParams;
     use edgezero_core::proxy::{ProxyClient, ProxyHandle, ProxyResponse};
     use edgezero_core::response::IntoResponse as _;
+    use edgezero_core::test_env::{EnvOverride, env_lock};
     use futures::executor::block_on;
     use std::collections::HashMap;
-    use std::env;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
 
     struct TestProxyClient;
 
@@ -153,39 +152,6 @@ mod tests {
             let (_method, uri, _headers, _body, _) = request.into_parts();
             assert!(uri.to_string().contains("status/201"));
             Ok(ProxyResponse::new(StatusCode::CREATED, Body::empty()))
-        }
-    }
-
-    /// Serializes every test that reads or writes the `API_BASE_URL`
-    /// process-global env var -- concurrent `env::set_var` / `env::var`
-    /// across threads is unsound, so these tests must not overlap.
-    fn env_lock() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
-
-    /// Restores `API_BASE_URL` to its prior value when dropped, so a
-    /// panicking assertion cannot leak process-global state.
-    struct EnvVarGuard {
-        original: Option<String>,
-    }
-
-    impl EnvVarGuard {
-        fn set(value: &str) -> Self {
-            let original = env::var("API_BASE_URL").ok();
-            env::set_var("API_BASE_URL", value);
-            Self { original }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match &self.original {
-                Some(value) => env::set_var("API_BASE_URL", value),
-                None => env::remove_var("API_BASE_URL"),
-            }
         }
     }
 
@@ -261,8 +227,8 @@ mod tests {
 
     #[test]
     fn build_proxy_target_merges_segments_and_query() {
-        let _lock = env_lock();
-        let _env = EnvVarGuard::set("https://example.com/api");
+        let _lock = env_lock().lock().expect("env lock");
+        let _env = EnvOverride::set("API_BASE_URL", "https://example.com/api");
         let original = Uri::from_static("/proxy/status?foo=bar");
         let target = build_proxy_target("status/200", &original).expect("target uri");
         assert_eq!(
@@ -273,7 +239,7 @@ mod tests {
 
     #[test]
     fn proxy_demo_without_handle_returns_placeholder() {
-        let _lock = env_lock();
+        let _lock = env_lock().lock().expect("env lock");
         let ctx = context_with_params("/proxy/status/200", &[("rest", "status/200")]);
         let response = block_on(proxy_demo(ctx)).expect("response");
         assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
@@ -281,7 +247,7 @@ mod tests {
 
     #[test]
     fn proxy_demo_uses_injected_handle() {
-        let _lock = env_lock();
+        let _lock = env_lock().lock().expect("env lock");
 
         let mut request = request_builder()
             .method(Method::GET)

--- a/crates/edgezero-cli/src/templates/root/Cargo.toml.hbs
+++ b/crates/edgezero-cli/src/templates/root/Cargo.toml.hbs
@@ -6,6 +6,13 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+authors = []
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+version = "0.1.0"
+
 [workspace.dependencies]
 {{{workspace_dependencies}}}
 

--- a/crates/edgezero-cli/src/templates/root/Cargo.toml.hbs
+++ b/crates/edgezero-cli/src/templates/root/Cargo.toml.hbs
@@ -8,7 +8,7 @@ resolver = "2"
 
 [workspace.package]
 authors = []
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 publish = false
 version = "0.1.0"

--- a/crates/edgezero-cli/src/test_support.rs
+++ b/crates/edgezero-cli/src/test_support.rs
@@ -13,8 +13,13 @@
 //! can share the harness without each duplicating the BASIC /
 //! PROVISION manifest fixtures.
 
-use std::env;
 use std::sync::{Mutex, OnceLock};
+
+/// RAII guard that overrides a process-global env var for the duration of a
+/// test and restores the prior value on drop. Acquire [`manifest_guard`] BEFORE
+/// constructing one, and hold it for the guard's lifetime — that is the safety
+/// contract documented on `edgezero_core::test_env`.
+pub(crate) use edgezero_core::test_env::EnvOverride;
 
 /// `provision` dispatch fixture: declares axum + fastly +
 /// cloudflare + spin (every adapter the build registers), with
@@ -93,46 +98,6 @@ auth-login = "echo logged in"
 auth-logout = "echo logged out"
 auth-status = "echo whoami"
 "#;
-
-/// RAII guard that sets a process-global env var for the duration
-/// of a test and restores the prior value (or removes it) on drop.
-/// Use together with [`manifest_guard`] when overriding
-/// `EDGEZERO_MANIFEST` so concurrent tests don't observe the
-/// override.
-pub(crate) struct EnvOverride {
-    key: &'static str,
-    original: Option<String>,
-}
-
-impl Drop for EnvOverride {
-    fn drop(&mut self) {
-        if let Some(original) = &self.original {
-            env::set_var(self.key, original);
-        } else {
-            env::remove_var(self.key);
-        }
-    }
-}
-
-impl EnvOverride {
-    /// Remove the env var (if set) for the duration of the test
-    /// scope, capturing the prior value so drop can restore it.
-    /// Use when a test needs the "no override" code path but the
-    /// parent shell may have exported a value.
-    pub(crate) fn remove(key: &'static str) -> Self {
-        let original = env::var(key).ok();
-        env::remove_var(key);
-        Self { key, original }
-    }
-
-    /// Set the env var to `value` for the duration of the test
-    /// scope, capturing the prior value so drop can restore it.
-    pub(crate) fn set(key: &'static str, value: &str) -> Self {
-        let original = env::var(key).ok();
-        env::set_var(key, value);
-        Self { key, original }
-    }
-}
 
 /// Process-wide mutex serialising tests that mutate `EDGEZERO_MANIFEST`
 /// or otherwise observe global adapter-registry state. Acquire it

--- a/crates/edgezero-cli/tests/lib_consumer.rs
+++ b/crates/edgezero-cli/tests/lib_consumer.rs
@@ -13,7 +13,7 @@
 mod tests {
     use edgezero_cli::args::BuildArgs;
     use edgezero_cli::run_build;
-    use std::env;
+    use edgezero_core::test_env::EnvOverride;
     use std::fs;
     use tempfile::TempDir;
 
@@ -28,35 +28,13 @@ deploy = "echo deploy"
 serve = "echo serve"
 "#;
 
-    /// RAII guard that restores `EDGEZERO_MANIFEST` to its prior value on drop.
-    struct EnvOverride {
-        original: Option<String>,
-    }
-
-    impl Drop for EnvOverride {
-        fn drop(&mut self) {
-            match &self.original {
-                Some(value) => env::set_var("EDGEZERO_MANIFEST", value),
-                None => env::remove_var("EDGEZERO_MANIFEST"),
-            }
-        }
-    }
-
-    impl EnvOverride {
-        fn set(value: &str) -> Self {
-            let original = env::var("EDGEZERO_MANIFEST").ok();
-            env::set_var("EDGEZERO_MANIFEST", value);
-            Self { original }
-        }
-    }
-
     #[cfg(not(windows))]
     #[test]
     fn external_consumer_can_call_run_build() {
         let temp = TempDir::new().expect("temp dir");
         let manifest_path = temp.path().join("edgezero.toml");
         fs::write(&manifest_path, BASIC_MANIFEST).expect("write manifest");
-        let _env = EnvOverride::set(&manifest_path.to_string_lossy());
+        let _env = EnvOverride::set("EDGEZERO_MANIFEST", &*manifest_path.to_string_lossy());
 
         // Construct via `Default` + field mutation — the path that works for
         // an external crate even though `BuildArgs` is `#[non_exhaustive]`.

--- a/crates/edgezero-core/Cargo.toml
+++ b/crates/edgezero-core/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "edgezero-core"
-edition = { workspace = true }
-version = { workspace = true }
 authors = { workspace = true }
+edition = { workspace = true }
 license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/edgezero-core/Cargo.toml
+++ b/crates/edgezero-core/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "edgezero-core"
+description = "Core routing, extractors, middleware, and proxy primitives for EdgeZero"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/edgezero-core/src/app.rs
+++ b/crates/edgezero-core/src/app.rs
@@ -156,7 +156,7 @@ mod tests {
     use crate::body::Body;
     use crate::context::RequestContext;
     use crate::error::EdgeError;
-    use crate::http::{request_builder, Method, StatusCode};
+    use crate::http::{Method, StatusCode, request_builder};
     use futures::executor::block_on;
     use tower_service::Service as _;
 

--- a/crates/edgezero-core/src/app_config.rs
+++ b/crates/edgezero-core/src/app_config.rs
@@ -25,9 +25,9 @@ use std::thread_local;
 
 use serde::de::DeserializeOwned;
 use thiserror::Error;
+use toml::Value;
 use toml::de::Error as TomlDeError;
 use toml::value::Datetime;
-use toml::Value;
 use validator::{Validate, ValidationErrors};
 
 /// One segment of a [`SecretField`] path.
@@ -347,23 +347,21 @@ fn prune_secret_leaf(errors: &mut ValidationErrors, path: &[SecretPathSegment]) 
         };
 
     let mut clear = false;
-    if kind_is_array {
-        if let Some(ValidationErrorsKind::List(items)) = errors.errors_mut().get_mut(name.as_ref())
-        {
-            for inner in items.values_mut() {
-                prune_secret_leaf(inner, tail);
-            }
-            items.retain(|_, inner| !inner.errors().is_empty());
-            clear = items.is_empty();
-        }
-    }
-    if !kind_is_array {
-        if let Some(ValidationErrorsKind::Struct(inner)) =
-            errors.errors_mut().get_mut(name.as_ref())
-        {
+    if kind_is_array
+        && let Some(ValidationErrorsKind::List(items)) = errors.errors_mut().get_mut(name.as_ref())
+    {
+        for inner in items.values_mut() {
             prune_secret_leaf(inner, tail);
-            clear = inner.errors().is_empty();
         }
+        items.retain(|_, inner| !inner.errors().is_empty());
+        clear = items.is_empty();
+    }
+    if !kind_is_array
+        && let Some(ValidationErrorsKind::Struct(inner)) =
+            errors.errors_mut().get_mut(name.as_ref())
+    {
+        prune_secret_leaf(inner, tail);
+        clear = inner.errors().is_empty();
     }
     if clear {
         errors.errors_mut().remove(name.as_ref());
@@ -743,6 +741,7 @@ fn walk_and_overlay(
 )]
 mod tests {
     use super::*;
+    use crate::test_env::{EnvOverride, env_lock};
     use serde::Deserialize;
     use std::io::Write as _;
     use tempfile::NamedTempFile;
@@ -1077,14 +1076,14 @@ timeout_ms = 1500
         );
         let app_name = "overlay_disabled_test";
         let env_key = "OVERLAY_DISABLED_TEST__GREETING";
-        env::set_var(env_key, "should-be-ignored");
+        let _lock = env_lock().lock().expect("env lock");
+        let _override = EnvOverride::set(env_key, "should-be-ignored");
         let cfg = load_app_config_with_options::<FixtureConfig>(
             file.path(),
             app_name,
             &AppConfigLoadOptions { env_overlay: false },
         )
         .expect("load");
-        env::remove_var(env_key);
         assert_eq!(cfg.greeting, "hello", "overlay disabled: file value wins");
     }
 

--- a/crates/edgezero-core/src/body.rs
+++ b/crates/edgezero-core/src/body.rs
@@ -3,8 +3,8 @@ use std::io;
 
 use bytes::Bytes;
 use futures_util::stream::{LocalBoxStream, Stream, StreamExt};
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 
 use crate::error::EdgeError;
 

--- a/crates/edgezero-core/src/compression.rs
+++ b/crates/edgezero-core/src/compression.rs
@@ -3,9 +3,9 @@ use std::io;
 use async_compression::futures::bufread::{BrotliDecoder, GzipDecoder};
 use async_stream::try_stream;
 use bytes::Bytes;
+use futures::TryStream;
 use futures::io::{AsyncReadExt as _, BufReader};
 use futures::stream::Stream;
-use futures::TryStream;
 use futures_util::TryStreamExt as _;
 
 const BUFFER_SIZE: usize = 8 * 1024;
@@ -66,7 +66,7 @@ where
 mod tests {
     use super::*;
     use brotli::CompressorWriter;
-    use flate2::{write::GzEncoder, Compression};
+    use flate2::{Compression, write::GzEncoder};
     use futures::executor::block_on;
     use futures_util::stream;
     use std::io::Write as _;

--- a/crates/edgezero-core/src/context.rs
+++ b/crates/edgezero-core/src/context.rs
@@ -219,7 +219,7 @@ impl RequestContext {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::http::{request_builder, HeaderValue, Method, StatusCode, Uri};
+    use crate::http::{HeaderValue, Method, StatusCode, Uri, request_builder};
     use crate::params::PathParams;
     use crate::proxy::{ProxyClient, ProxyHandle, ProxyRequest, ProxyResponse};
     use async_trait::async_trait;
@@ -290,9 +290,10 @@ mod tests {
         let ctx = ctx("/submit", body, PathParams::default());
         let err = ctx.form::<serde_json::Value>().expect_err("expected error");
         assert_eq!(err.status(), StatusCode::BAD_REQUEST);
-        assert!(err
-            .message()
-            .contains("streaming bodies are not supported for form extraction"));
+        assert!(
+            err.message()
+                .contains("streaming bodies are not supported for form extraction")
+        );
     }
 
     #[test]

--- a/crates/edgezero-core/src/error.rs
+++ b/crates/edgezero-core/src/error.rs
@@ -7,10 +7,10 @@ use thiserror::Error;
 use crate::body::Body;
 use crate::config_store::ConfigStoreError;
 use crate::http::{
-    header::{CONTENT_TYPE, RETRY_AFTER},
     HeaderValue, Method, Response, StatusCode,
+    header::{CONTENT_TYPE, RETRY_AFTER},
 };
-use crate::response::{response_with_body, IntoResponse};
+use crate::response::{IntoResponse, response_with_body};
 
 /// Application-level error that carries an HTTP status code.
 #[derive(Debug, Error)]

--- a/crates/edgezero-core/src/extractor.rs
+++ b/crates/edgezero-core/src/extractor.rs
@@ -1006,7 +1006,7 @@ async fn resolve_leaf(
             return Err(EdgeError::config_out_of_date(
                 format!("missing or non-string value at `{leaf_path}`"),
                 leaf_path,
-            ))
+            ));
         }
     };
 
@@ -1147,7 +1147,7 @@ mod tests {
     use crate::body::Body;
     use crate::config_store::{ConfigStore, ConfigStoreError, ConfigStoreHandle};
     use crate::context::RequestContext;
-    use crate::http::{request_builder, HeaderValue, Method, StatusCode};
+    use crate::http::{HeaderValue, Method, StatusCode, request_builder};
     use crate::params::PathParams;
     use crate::secret_store::{InMemorySecretStore, NoopSecretStore, SecretHandle, SecretStore};
     use crate::store_registry::StoreRegistry;
@@ -2594,9 +2594,10 @@ mod tests {
         let err = block_on(secret_walk::<NestedCfg>(&ctx, &mut data))
             .expect_err("missing required nested leaf");
         assert_eq!(err.status(), StatusCode::SERVICE_UNAVAILABLE);
-        assert!(err
-            .to_string()
-            .contains("integrations.datadome.server_side_key"));
+        assert!(
+            err.to_string()
+                .contains("integrations.datadome.server_side_key")
+        );
     }
 
     #[test]

--- a/crates/edgezero-core/src/handler.rs
+++ b/crates/edgezero-core/src/handler.rs
@@ -78,7 +78,7 @@ where
 mod tests {
     use super::*;
     use crate::body::Body;
-    use crate::http::{request_builder, Method, StatusCode};
+    use crate::http::{Method, StatusCode, request_builder};
     use crate::params::PathParams;
     use futures::executor::block_on;
 

--- a/crates/edgezero-core/src/introspection.rs
+++ b/crates/edgezero-core/src/introspection.rs
@@ -8,7 +8,7 @@ use crate::error::EdgeError;
 use crate::extractor::FromRequest;
 // NOTE: `Response` is an HTTP alias exported from `crate::http`, NOT
 // `crate::response` (response.rs itself imports it from crate::http).
-use crate::http::{response_builder, Response, StatusCode};
+use crate::http::{Response, StatusCode, response_builder};
 use crate::router::RouteInfo;
 use async_trait::async_trait;
 use edgezero_core::action;
@@ -112,7 +112,7 @@ pub async fn config(ctx: RequestContext) -> Result<Response, EdgeError> {
 mod tests {
     use super::*;
     use crate::config_store::{ConfigStore, ConfigStoreError, ConfigStoreHandle};
-    use crate::http::{request_builder, Method, Response};
+    use crate::http::{Method, Response, request_builder};
     use crate::router::RouterService;
     use crate::store_registry::{ConfigRegistry, ConfigStoreBinding, StoreRegistry};
     use async_trait::async_trait;
@@ -234,9 +234,10 @@ mod tests {
         // Shape: [{ "method", "path" }] — the /r route itself is present.
         let body = body_json(resp);
         let arr = body.as_array().expect("routes array");
-        assert!(arr
-            .iter()
-            .any(|entry| entry["method"] == "GET" && entry["path"] == "/r"));
+        assert!(
+            arr.iter()
+                .any(|entry| entry["method"] == "GET" && entry["path"] == "/r")
+        );
     }
 
     #[test]

--- a/crates/edgezero-core/src/key_value_store.rs
+++ b/crates/edgezero-core/src/key_value_store.rs
@@ -277,11 +277,13 @@ macro_rules! key_value_store_contract_tests {
                         .await
                         .unwrap();
                     assert!(second.keys.iter().all(|key| key.starts_with("prefix/")));
-                    assert!(first
-                        .keys
-                        .iter()
-                        .chain(second.keys.iter())
-                        .all(|key| key.starts_with("prefix/")));
+                    assert!(
+                        first
+                            .keys
+                            .iter()
+                            .chain(second.keys.iter())
+                            .all(|key| key.starts_with("prefix/"))
+                    );
                 });
             }
         }
@@ -1021,11 +1023,11 @@ mod tests {
 
         async fn get_bytes(&self, key: &str) -> Result<Option<Bytes>, KvError> {
             let mut data = self.data.lock().unwrap();
-            if let Some((_, Some(exp))) = data.get(key) {
-                if SystemTime::now() >= *exp {
-                    data.remove(key);
-                    return Ok(None);
-                }
+            if let Some((_, Some(exp))) = data.get(key)
+                && SystemTime::now() >= *exp
+            {
+                data.remove(key);
+                return Ok(None);
             }
             Ok(data.get(key).map(|(value, _)| value.clone()))
         }

--- a/crates/edgezero-core/src/lib.rs
+++ b/crates/edgezero-core/src/lib.rs
@@ -38,5 +38,9 @@ pub mod response;
 pub mod router;
 pub mod secret_store;
 pub mod store_registry;
+/// Test-only env-var guards. The workspace's only `unsafe` lives here; see the
+/// module docs. Enable via the `test-utils` feature in `[dev-dependencies]`.
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_env;
 
-pub use edgezero_macros::{action, app, AppConfig};
+pub use edgezero_macros::{AppConfig, action, app};

--- a/crates/edgezero-core/src/manifest.rs
+++ b/crates/edgezero-core/src/manifest.rs
@@ -1005,13 +1005,13 @@ fn validate_store_declaration(declaration: &StoreDeclaration) -> Result<(), Vali
         return Err(error);
     }
 
-    if let Some(default) = declaration.default.as_deref() {
-        if !declaration.ids.iter().any(|id| id == default) {
-            let mut error = ValidationError::new("store_default_unknown");
-            error.message =
-                Some(format!("`default` (`{default}`) must be one of the declared `ids`").into());
-            return Err(error);
-        }
+    if let Some(default) = declaration.default.as_deref()
+        && !declaration.ids.iter().any(|id| id == default)
+    {
+        let mut error = ValidationError::new("store_default_unknown");
+        error.message =
+            Some(format!("`default` (`{default}`) must be one of the declared `ids`").into());
+        return Err(error);
     }
 
     Ok(())
@@ -1022,7 +1022,7 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
     use std::process;
-    use tempfile::{tempdir, tempdir_in, NamedTempFile};
+    use tempfile::{NamedTempFile, tempdir, tempdir_in};
 
     const SAMPLE: &str = r#"
 [app]
@@ -1452,9 +1452,10 @@ level = "off"
     fn log_level_rejects_invalid_value() {
         let err = toml::from_str::<ManifestLoggingConfig>("level = \"loud\"")
             .expect_err("invalid log level");
-        assert!(err
-            .to_string()
-            .contains("logging level must be trace, debug, info, warn, error, or off"));
+        assert!(
+            err.to_string()
+                .contains("logging level must be trace, debug, info, warn, error, or off")
+        );
     }
 
     #[test]

--- a/crates/edgezero-core/src/middleware.rs
+++ b/crates/edgezero-core/src/middleware.rs
@@ -126,7 +126,7 @@ mod tests {
     use super::*;
     use crate::body::Body;
     use crate::handler::IntoHandler as _;
-    use crate::http::{request_builder, Method, Response, StatusCode};
+    use crate::http::{Method, Response, StatusCode, request_builder};
     use crate::params::PathParams;
     use crate::response::response_with_body;
     use futures::executor::block_on;

--- a/crates/edgezero-core/src/proxy.rs
+++ b/crates/edgezero-core/src/proxy.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use crate::body::Body;
 use crate::error::EdgeError;
 use crate::http::{
-    response_builder, Extensions, HeaderMap, Method, Request, Response, StatusCode, Uri,
+    Extensions, HeaderMap, Method, Request, Response, StatusCode, Uri, response_builder,
 };
 
 /// Header name attached to proxied responses to identify which adapter
@@ -258,10 +258,10 @@ mod tests {
     use super::*;
     use crate::body::Body;
     use crate::http::header::HeaderName;
-    use crate::http::{request_builder, HeaderValue, Method, StatusCode, Uri};
+    use crate::http::{HeaderValue, Method, StatusCode, Uri, request_builder};
     use bytes::Bytes;
     use futures::executor::block_on;
-    use futures_util::{stream, StreamExt as _};
+    use futures_util::{StreamExt as _, stream};
 
     struct EchoBodyClient;
 

--- a/crates/edgezero-core/src/response.rs
+++ b/crates/edgezero-core/src/response.rs
@@ -1,8 +1,8 @@
 use crate::body::Body;
 use crate::error::EdgeError;
 use crate::http::{
-    header::{CONTENT_LENGTH, CONTENT_TYPE},
     HeaderValue, Response, StatusCode,
+    header::{CONTENT_LENGTH, CONTENT_TYPE},
 };
 
 /// Convert common return types into `Response`.
@@ -95,15 +95,15 @@ pub fn response_with_body(status: StatusCode, body: Body) -> Result<Response, Ed
 
     let mut builder = response_builder().status(status);
 
-    if let Body::Once(bytes) = &body {
-        if !bytes.is_empty() {
-            builder = builder
-                .header(CONTENT_LENGTH, bytes.len().to_string())
-                .header(
-                    CONTENT_TYPE,
-                    HeaderValue::from_static("text/plain; charset=utf-8"),
-                );
-        }
+    if let Body::Once(bytes) = &body
+        && !bytes.is_empty()
+    {
+        builder = builder
+            .header(CONTENT_LENGTH, bytes.len().to_string())
+            .header(
+                CONTENT_TYPE,
+                HeaderValue::from_static("text/plain; charset=utf-8"),
+            );
     }
 
     builder.body(body).map_err(EdgeError::internal)

--- a/crates/edgezero-core/src/router.rs
+++ b/crates/edgezero-core/src/router.rs
@@ -236,12 +236,12 @@ impl RouterInner {
                 // Inject only the introspection payloads this route asked for —
                 // nothing for the vast majority of routes that need none.
                 let needs = entry.introspection_needs;
-                if needs.manifest {
-                    if let Some(json) = &self.manifest_json {
-                        request
-                            .extensions_mut()
-                            .insert(ManifestJson(Arc::clone(json)));
-                    }
+                if needs.manifest
+                    && let Some(json) = &self.manifest_json
+                {
+                    request
+                        .extensions_mut()
+                        .insert(ManifestJson(Arc::clone(json)));
                 }
                 if needs.routes {
                     request
@@ -267,17 +267,17 @@ impl RouterInner {
     }
 
     fn find_route(&self, method: &Method, path: &str) -> RouteMatch<'_> {
-        if let Some(router) = self.routes.get(method) {
-            if let Ok(matched) = router.at(path) {
-                let params = PathParams::new(
-                    matched
-                        .params
-                        .iter()
-                        .map(|(key, value)| (key.to_owned(), value.to_owned()))
-                        .collect(),
-                );
-                return RouteMatch::Found(matched.value, params);
-            }
+        if let Some(router) = self.routes.get(method)
+            && let Ok(matched) = router.at(path)
+        {
+            let params = PathParams::new(
+                matched
+                    .params
+                    .iter()
+                    .map(|(key, value)| (key.to_owned(), value.to_owned()))
+                    .collect(),
+            );
+            return RouteMatch::Found(matched.value, params);
         }
 
         let allowed: HashSet<Method> = self
@@ -509,7 +509,7 @@ mod tests {
     use crate::body::Body;
     use crate::context::RequestContext;
     use crate::error::EdgeError;
-    use crate::http::{request_builder, Method, Request, Response, StatusCode};
+    use crate::http::{Method, Request, Response, StatusCode, request_builder};
     use crate::params::PathParams;
     use crate::response::response_with_body;
     use futures::executor::block_on;
@@ -772,8 +772,8 @@ mod tests {
     #[test]
     fn streams_body_through_router() {
         use bytes::Bytes;
-        use futures_util::stream;
         use futures_util::StreamExt as _;
+        use futures_util::stream;
 
         async fn handler(_ctx: RequestContext) -> Result<Response, EdgeError> {
             let chunks = stream::iter(vec![
@@ -898,15 +898,15 @@ mod tests {
         let mut r1 = None;
         let mut r2 = None;
         while r1.is_none() || r2.is_none() {
-            if r1.is_none() {
-                if let Poll::Ready(value) = f1.as_mut().poll(&mut cx) {
-                    r1 = Some(value);
-                }
+            if r1.is_none()
+                && let Poll::Ready(value) = f1.as_mut().poll(&mut cx)
+            {
+                r1 = Some(value);
             }
-            if r2.is_none() {
-                if let Poll::Ready(value) = f2.as_mut().poll(&mut cx) {
-                    r2 = Some(value);
-                }
+            if r2.is_none()
+                && let Poll::Ready(value) = f2.as_mut().poll(&mut cx)
+            {
+                r2 = Some(value);
             }
         }
 

--- a/crates/edgezero-core/src/test_env.rs
+++ b/crates/edgezero-core/src/test_env.rs
@@ -1,0 +1,139 @@
+//! Test-only environment mutation, shared across the workspace.
+//!
+//! In edition 2024 `std::env::set_var` and `std::env::remove_var` are `unsafe`:
+//! the process environment is global mutable state, and a write racing another
+//! thread's read (including reads inside libc, e.g. `getaddrinfo` or `tzset`)
+//! is undefined behaviour.
+//!
+//! Rather than spread `unsafe` — and an `#[expect(unsafe_code)]` to opt out of
+//! the workspace's `unsafe_code = "deny"` lint — across every crate that
+//! overrides an env var in its tests, all mutation funnels through this module.
+//! It is the only place in the workspace that writes the environment, so the
+//! `unsafe` blocks and their safety argument live in exactly one file.
+//!
+//! # Safety contract
+//!
+//! The guards below are RAII: they capture the prior value on construction and
+//! restore it on drop, so a panicking test cannot leak state into the next one.
+//! That alone does not make concurrent mutation sound — callers must also
+//! serialise env-mutating tests on a process-wide mutex ([`env_lock`], or the
+//! calling crate's own equivalent) and hold it for the guard's whole lifetime.
+//! The `unsafe` here is sound only under that discipline, which is why this
+//! module is test-only and never compiled into a production build.
+
+// The workspace's only `unsafe`. See the module docs for the safety argument.
+#![expect(
+    unsafe_code,
+    reason = "std::env::{set_var, remove_var} are unsafe in edition 2024; centralised here so no other crate has to opt out of the unsafe_code deny"
+)]
+
+use std::env;
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+
+/// RAII guard that overrides an environment variable for the duration of a test
+/// and restores the prior value — or removes the variable if it was previously
+/// unset — on drop.
+///
+/// Construct it while holding [`env_lock`] (or the calling crate's equivalent);
+/// see the module docs for the full safety contract.
+pub struct EnvOverride {
+    key: OsString,
+    original: Option<OsString>,
+}
+
+/// RAII guard that prepends a directory to `PATH`, so a test can shadow a real
+/// CLI (`fastly`, `wrangler`, `spin`, …) with a stub, and restores the prior
+/// `PATH` on drop.
+pub struct PathPrepend {
+    _inner: EnvOverride,
+}
+
+impl EnvOverride {
+    /// Removes `key` until the guard is dropped.
+    #[inline]
+    #[must_use]
+    pub fn remove<K: AsRef<OsStr>>(key: K) -> Self {
+        let owned = key.as_ref().to_owned();
+        let original = env::var_os(&owned);
+        // SAFETY: the caller holds the env lock for this guard's lifetime, so no
+        // other thread reads or writes the environment concurrently.
+        let () = unsafe { env::remove_var(&owned) };
+        Self {
+            key: owned,
+            original,
+        }
+    }
+
+    /// Sets `key` to `value` until the guard is dropped.
+    #[inline]
+    #[must_use]
+    pub fn set<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, value: V) -> Self {
+        let owned = key.as_ref().to_owned();
+        let original = env::var_os(&owned);
+        // SAFETY: as above — the caller holds the env lock.
+        let () = unsafe { env::set_var(&owned, value.as_ref()) };
+        Self {
+            key: owned,
+            original,
+        }
+    }
+}
+
+impl Drop for EnvOverride {
+    #[inline]
+    fn drop(&mut self) {
+        match &self.original {
+            Some(original) => {
+                // SAFETY: as above — the caller holds the env lock for the whole
+                // lifetime of this guard, which includes its drop.
+                unsafe {
+                    env::set_var(&self.key, original);
+                }
+            }
+            None => {
+                // SAFETY: as above.
+                unsafe {
+                    env::remove_var(&self.key);
+                }
+            }
+        }
+    }
+}
+
+impl PathPrepend {
+    /// Prepends `extra` to `PATH` until the guard is dropped.
+    #[inline]
+    #[must_use]
+    pub fn new(extra: &Path) -> Self {
+        let separator = if cfg!(windows) { ";" } else { ":" };
+        let new_path = match env::var_os("PATH") {
+            Some(prev) if !prev.is_empty() => {
+                let mut accum = OsString::from(extra);
+                accum.push(separator);
+                accum.push(prev);
+                accum
+            }
+            _ => OsString::from(extra),
+        };
+        Self {
+            _inner: EnvOverride::set("PATH", new_path),
+        }
+    }
+}
+
+/// Process-wide mutex serialising env-mutating tests within a single test
+/// binary. Acquire it before constructing any guard above and hold it for the
+/// guard's lifetime; that is what makes the `unsafe` in this module sound.
+///
+/// One lock per test binary is sufficient: Cargo compiles each crate's tests
+/// into their own process, so cross-crate races are impossible. Crates whose
+/// env-touching tests are `async` own an equivalent `tokio::sync::Mutex`
+/// instead (a `std` guard cannot be held across an `.await`).
+#[inline]
+#[must_use]
+pub fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}

--- a/crates/edgezero-macros/Cargo.toml
+++ b/crates/edgezero-macros/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "edgezero-macros"
-edition = { workspace = true }
-version = { workspace = true }
 authors = { workspace = true }
+edition = { workspace = true }
 license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/edgezero-macros/Cargo.toml
+++ b/crates/edgezero-macros/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "edgezero-macros"
+description = "Procedural macros (#[action], #[app]) for EdgeZero"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/edgezero-macros/src/action.rs
+++ b/crates/edgezero-macros/src/action.rs
@@ -2,7 +2,7 @@ use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse::Parser as _;
 use syn::punctuated::Punctuated;
-use syn::{spanned::Spanned as _, Error, FnArg, ItemFn, Pat, PathArguments, Token, Type};
+use syn::{Error, FnArg, ItemFn, Pat, PathArguments, Token, Type, spanned::Spanned as _};
 
 /// `(extract_stmts, arg_idents)` produced from a handler's argument list — the
 /// `FromRequest` extraction statements and the idents passed to the inner fn.
@@ -68,7 +68,7 @@ fn expand_action_impl(
         Err(err) => return err.to_compile_error(),
     };
 
-    let output = if is_capability_handler {
+    if is_capability_handler {
         // A fn can't carry per-handler data past type-erasure into
         // `Arc<dyn DynHandler>`, so an opt-in handler becomes a unit struct with
         // its own `DynHandler` impl whose `introspection_needs()` reports which
@@ -115,9 +115,7 @@ fn expand_action_impl(
                 ::edgezero_core::responder::Responder::respond(result)
             }
         }
-    };
-
-    output
+    }
 }
 
 /// Parse the optional `#[action(...)]` capability list into
@@ -231,15 +229,14 @@ fn path_is_request_context(path: &syn::Path) -> bool {
 fn normalize_request_context_patterns(func: &mut ItemFn) -> Result<(), Error> {
     let mut error: Option<Error> = None;
     for arg in &mut func.sig.inputs {
-        if let FnArg::Typed(pat_type) = arg {
-            if is_request_context_type(&pat_type.ty) {
-                if let Err(err) = normalize_request_context_pat(&mut pat_type.pat) {
-                    if let Some(existing) = error.as_mut() {
-                        existing.combine(err);
-                    } else {
-                        error = Some(err);
-                    }
-                }
+        if let FnArg::Typed(pat_type) = arg
+            && is_request_context_type(&pat_type.ty)
+            && let Err(err) = normalize_request_context_pat(&mut pat_type.pat)
+        {
+            if let Some(existing) = error.as_mut() {
+                existing.combine(err);
+            } else {
+                error = Some(err);
             }
         }
     }

--- a/crates/edgezero-macros/src/app.rs
+++ b/crates/edgezero-macros/src/app.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 use syn::parse::{Parse, ParseStream};
-use syn::{parse_macro_input, Ident, LitStr, Token};
+use syn::{Ident, LitStr, Token, parse_macro_input};
 use validator::Validate as _;
 
 #[derive(Debug)]
@@ -335,7 +335,7 @@ fn route_for_method(method: &str, path: &LitStr, handler: &syn::ExprPath) -> Tok
 
 #[cfg(test)]
 mod tests {
-    use super::{build_route_tokens, parse_handler_path, AppArgs, Manifest};
+    use super::{AppArgs, Manifest, build_route_tokens, parse_handler_path};
     use syn::parse_str;
 
     #[test]

--- a/crates/edgezero-macros/src/app_config.rs
+++ b/crates/edgezero-macros/src/app_config.rs
@@ -12,8 +12,8 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 use syn::punctuated::Punctuated;
 use syn::{
-    parse_macro_input, Attribute, Data, DeriveInput, Expr, ExprLit, Field, Fields, GenericArgument,
-    Ident, Lit, Meta, MetaNameValue, Path, PathArguments, Type,
+    Attribute, Data, DeriveInput, Expr, ExprLit, Field, Fields, GenericArgument, Ident, Lit, Meta,
+    MetaNameValue, Path, PathArguments, Type, parse_macro_input,
 };
 
 /// Recognised `#[secret(...)]` annotation kinds.
@@ -451,16 +451,13 @@ fn type_is_bare_ident(ty: &Type, ident: &syn::Ident) -> bool {
 
 /// `Vec<T>` / `[T]` -> (T, true); otherwise (`field_ty`, false).
 fn nested_child_type(ty: &Type) -> (&Type, bool) {
-    if let Type::Path(type_path) = ty {
-        if let Some(last) = type_path.path.segments.last() {
-            if last.ident == "Vec" {
-                if let PathArguments::AngleBracketed(bracketed) = &last.arguments {
-                    if let Some(GenericArgument::Type(inner)) = bracketed.args.first() {
-                        return (inner, true);
-                    }
-                }
-            }
-        }
+    if let Type::Path(type_path) = ty
+        && let Some(last) = type_path.path.segments.last()
+        && last.ident == "Vec"
+        && let PathArguments::AngleBracketed(bracketed) = &last.arguments
+        && let Some(GenericArgument::Type(inner)) = bracketed.args.first()
+    {
+        return (inner, true);
     }
     if let Type::Slice(slice) = ty {
         return (&slice.elem, true);
@@ -476,24 +473,22 @@ fn parse_secret_kind(attr: &Attribute) -> Result<SecretAnnotation, syn::Error> {
         Meta::Path(_) => Ok(SecretAnnotation::KeyInDefault),
         Meta::List(list) => {
             // Try `store_ref = "field"` first (name-value form).
-            if let Ok(nv) = syn::parse2::<MetaNameValue>(list.tokens.clone()) {
-                if nv.path.is_ident("store_ref") {
-                    if let Expr::Lit(ExprLit {
-                        lit: Lit::Str(str_lit),
-                        ..
-                    }) = nv.value
-                    {
-                        return Ok(SecretAnnotation::KeyInNamedStore {
-                            store_ref_field: str_lit.value(),
-                        });
-                    }
-                }
+            if let Ok(nv) = syn::parse2::<MetaNameValue>(list.tokens.clone())
+                && nv.path.is_ident("store_ref")
+                && let Expr::Lit(ExprLit {
+                    lit: Lit::Str(str_lit),
+                    ..
+                }) = nv.value
+            {
+                return Ok(SecretAnnotation::KeyInNamedStore {
+                    store_ref_field: str_lit.value(),
+                });
             }
             // Try bare `store_ref` path.
-            if let Ok(path) = syn::parse2::<Path>(list.tokens.clone()) {
-                if path.is_ident("store_ref") {
-                    return Ok(SecretAnnotation::StoreRef);
-                }
+            if let Ok(path) = syn::parse2::<Path>(list.tokens.clone())
+                && path.is_ident("store_ref")
+            {
+                return Ok(SecretAnnotation::StoreRef);
             }
             Err(syn::Error::new_spanned(
                 &list.tokens,
@@ -515,29 +510,24 @@ fn secret_string_optionality(ty: &Type) -> Option<bool> {
     if is_scalar_string_type(ty) {
         return Some(false);
     }
-    if let Type::Path(type_path) = ty {
-        if let Some(last) = type_path.path.segments.last() {
-            if last.ident == "Option" {
-                if let PathArguments::AngleBracketed(bracketed) = &last.arguments {
-                    if let Some(GenericArgument::Type(inner)) = bracketed.args.first() {
-                        if is_scalar_string_type(inner) {
-                            return Some(true);
-                        }
-                    }
-                }
-            }
-        }
+    if let Type::Path(type_path) = ty
+        && let Some(last) = type_path.path.segments.last()
+        && last.ident == "Option"
+        && let PathArguments::AngleBracketed(bracketed) = &last.arguments
+        && let Some(GenericArgument::Type(inner)) = bracketed.args.first()
+        && is_scalar_string_type(inner)
+    {
+        return Some(true);
     }
     None
 }
 
 fn is_scalar_string_type(ty: &Type) -> bool {
-    if let Type::Path(type_path) = ty {
-        if type_path.qself.is_none() {
-            if let Some(last) = type_path.path.segments.last() {
-                return last.ident == "String" && last.arguments.is_empty();
-            }
-        }
+    if let Type::Path(type_path) = ty
+        && type_path.qself.is_none()
+        && let Some(last) = type_path.path.segments.last()
+    {
+        return last.ident == "String" && last.arguments.is_empty();
     }
     false
 }

--- a/crates/edgezero-macros/tests/action_state.rs
+++ b/crates/edgezero-macros/tests/action_state.rs
@@ -10,7 +10,7 @@ mod tests {
     use edgezero_core::body::Body;
     use edgezero_core::error::EdgeError;
     use edgezero_core::extractor::{Query, State};
-    use edgezero_core::http::{request_builder, Method, StatusCode};
+    use edgezero_core::http::{Method, StatusCode, request_builder};
     use edgezero_core::router::RouterService;
     use futures::executor::block_on;
     use serde::Deserialize;

--- a/crates/edgezero-macros/tests/nested_secrets_e2e.rs
+++ b/crates/edgezero-macros/tests/nested_secrets_e2e.rs
@@ -17,7 +17,7 @@ use edgezero_core::body::Body;
 use edgezero_core::config_store::{ConfigStore, ConfigStoreError, ConfigStoreHandle};
 use edgezero_core::context::RequestContext;
 use edgezero_core::extractor::{AppConfig as AppConfigExtractor, FromRequest as _};
-use edgezero_core::http::{request_builder, Method};
+use edgezero_core::http::{Method, request_builder};
 use edgezero_core::params::PathParams;
 use edgezero_core::secret_store::{InMemorySecretStore, SecretHandle};
 use edgezero_core::store_registry::{

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -455,11 +455,20 @@ Install the provider CLI:
 
 ## Building Your Own CLI
 
-`edgezero-cli` is published as a library as well as a binary. Every downstream
-command is exposed as a `(*Args, run_*)` pair (`BuildArgs` / `run_build`,
-`DeployArgs` / `run_deploy`, `NewArgs` / `run_new`, `ServeArgs` / `run_serve`),
-so a downstream project can build its own CLI binary that reuses any subset of
-the built-ins and adds its own subcommands:
+`edgezero-cli` ships a library as well as a binary. Every downstream command is
+exposed as a `(*Args, run_*)` pair (`BuildArgs` / `run_build`, `DeployArgs` /
+`run_deploy`, `NewArgs` / `run_new`, `ServeArgs` / `run_serve`), so a downstream
+project can build its own CLI binary that reuses any subset of the built-ins and
+adds its own subcommands.
+
+The crate is not on crates.io — EdgeZero crates are `publish = false` until the
+first registry release — so depend on it by Git (or by path, in a local
+checkout):
+
+```toml
+[dependencies]
+edgezero-cli = { git = "https://github.com/stackpop/edgezero.git", default-features = false }
+```
 
 ```rust
 use clap::{Parser, Subcommand};

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,10 +11,18 @@ This guide walks you through creating your first EdgeZero application.
 
 ## Installation
 
-Install the EdgeZero CLI from the workspace or a published crate:
+The EdgeZero crates are not published to crates.io. They are intentionally
+marked `publish = false` until the first registry release, so install the CLI
+from a local checkout:
 
 ```bash
 cargo install --path crates/edgezero-cli
+```
+
+Or straight from Git, without cloning first:
+
+```bash
+cargo install --git https://github.com/stackpop/edgezero.git edgezero-cli
 ```
 
 ## Create a New Project

--- a/examples/app-demo/Cargo.lock
+++ b/examples/app-demo/Cargo.lock
@@ -2763,19 +2763,10 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
+ "winnow",
 ]
 
 [[package]]
@@ -2789,15 +2780,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
@@ -2806,7 +2797,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -3474,18 +3465,12 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/examples/app-demo/Cargo.toml
+++ b/examples/app-demo/Cargo.toml
@@ -10,7 +10,11 @@ members = [
 resolver = "2"
 
 [workspace.package]
+authors = ["EdgeZero Team <dev@edgezero.dev>"]
+edition = "2021"
 license = "Apache-2.0"
+publish = false
+version = "0.1.0"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/examples/app-demo/crates/app-demo-adapter-axum/Cargo.toml
+++ b/examples/app-demo/crates/app-demo-adapter-axum/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "app-demo-adapter-axum"
-version = "0.1.0"
-edition = "2021"
-license.workspace = true
-publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/examples/app-demo/crates/app-demo-adapter-axum/Cargo.toml
+++ b/examples/app-demo/crates/app-demo-adapter-axum/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "app-demo-adapter-axum"
+description = "Axum adapter binary for the EdgeZero app-demo example"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/examples/app-demo/crates/app-demo-adapter-cloudflare/Cargo.toml
+++ b/examples/app-demo/crates/app-demo-adapter-cloudflare/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "app-demo-adapter-cloudflare"
-version = "0.1.0"
-edition = "2021"
-license.workspace = true
-publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/examples/app-demo/crates/app-demo-adapter-cloudflare/Cargo.toml
+++ b/examples/app-demo/crates/app-demo-adapter-cloudflare/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "app-demo-adapter-cloudflare"
+description = "Cloudflare Workers adapter binary for the EdgeZero app-demo example"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/examples/app-demo/crates/app-demo-adapter-fastly/Cargo.toml
+++ b/examples/app-demo/crates/app-demo-adapter-fastly/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "app-demo-adapter-fastly"
-version = "0.1.0"
-edition = "2021"
-license.workspace = true
-publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/examples/app-demo/crates/app-demo-adapter-fastly/Cargo.toml
+++ b/examples/app-demo/crates/app-demo-adapter-fastly/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "app-demo-adapter-fastly"
+description = "Fastly Compute adapter binary for the EdgeZero app-demo example"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/examples/app-demo/crates/app-demo-adapter-spin/Cargo.toml
+++ b/examples/app-demo/crates/app-demo-adapter-spin/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "app-demo-adapter-spin"
-version = "0.1.0"
-edition = "2021"
-license.workspace = true
-publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/examples/app-demo/crates/app-demo-adapter-spin/Cargo.toml
+++ b/examples/app-demo/crates/app-demo-adapter-spin/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "app-demo-adapter-spin"
+description = "Fermyon Spin adapter binary for the EdgeZero app-demo example"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/examples/app-demo/crates/app-demo-cli/Cargo.toml
+++ b/examples/app-demo/crates/app-demo-cli/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "app-demo-cli"
+description = "CLI entry point for the EdgeZero app-demo example"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/examples/app-demo/crates/app-demo-cli/Cargo.toml
+++ b/examples/app-demo/crates/app-demo-cli/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "app-demo-cli"
-version = "0.1.0"
-edition = "2021"
-license.workspace = true
-publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true

--- a/examples/app-demo/crates/app-demo-core/Cargo.toml
+++ b/examples/app-demo/crates/app-demo-core/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "app-demo-core"
+description = "Core handlers and configuration for the EdgeZero app-demo example"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/examples/app-demo/crates/app-demo-core/Cargo.toml
+++ b/examples/app-demo/crates/app-demo-core/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "app-demo-core"
-version = "0.1.0"
-edition = "2021"
-license.workspace = true
-publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

- **Unify package metadata.** Every crate in the repo now inherits the same five keys from its workspace root — `authors`, `edition`, `license`, `publish`, `version` — each as `{ workspace = true }`, in a consistent order. Previously six crates inherited only four (no `publish`), while `edgezero-adapter` and `edgezero-cli` hardcoded `version` / `edition` and declared no `authors` at all. `publish = false` is now declared once in `[workspace.package]` as a guard against an accidental `cargo publish` (nothing in CI publishes these crates).
- **Give every crate a description.** Only 2 of 20 crates had one; the other 18 now do, and the canonical `[package]` key order everywhere is `name, description, authors, edition, license, publish, version`.
- **Move the workspace to Rust edition 2024.** Rust 1.95 (`.tool-versions`) is well past the 1.85 minimum. The interesting consequence is `std::env::set_var` / `remove_var`, which are `unsafe` in 2024 — see below.

The same discipline is extended to the two places it was missing entirely: the separate `examples/app-demo` workspace and the `edgezero new` scaffolding templates, so scaffolded projects start out consistent with the repo they came from.

### The one design decision worth reviewing: `unsafe` env mutation under edition 2024

In edition 2024, `std::env::set_var` / `remove_var` are `unsafe` — the process environment is global mutable state, and a write racing another thread's read is UB. This repo had **34 call sites across five crates**, all test-only, all sitting inside near-identical copy-pasted RAII env guards.

The obvious fix — sprinkle `#[expect(unsafe_code)]` at each site to opt out of the workspace's `unsafe_code = "deny"` lint — would have scattered `unsafe` across five crates and left the duplication in place. Instead this PR adds **`edgezero_core::test_env`** (behind the existing `test-utils` feature) with shared `EnvOverride` / `PathPrepend` guards plus an `env_lock()` mutex, and deletes the five duplicate guard implementations.

Result: the workspace now contains **exactly one `#[expect(unsafe_code)]`**, and every `unsafe` block lives in that single file — which is never compiled into a production build.

Two smaller edition side effects: let-chains are stable in 2024, so clippy's `collapsible_if` now fires on nested `if let` + condition (collapsed those), and rustfmt's 2024 style edition reorders imports and moves some trailing semicolons — that accounts for most of the line count.

## Changes

| Crate / File | Change |
| ------------ | ------ |
| `Cargo.toml` (root) | `[workspace.package]`: add `publish = false`, flip `edition` to `2024` |
| `crates/edgezero-core/src/test_env.rs` | **New.** Shared `EnvOverride` / `PathPrepend` RAII guards + `env_lock()`, behind the `test-utils` feature. The single home for all `unsafe` in the workspace, holding the workspace's only `#[expect(unsafe_code)]` |
| `crates/edgezero-core/Cargo.toml` + `src/*` | Inherit all five keys; export `test_env`; edition-2024 fmt/clippy fixes |
| `crates/edgezero-macros/`, `crates/edgezero-adapter/` | Inherit all five keys (adapter drops hardcoded `version` / `edition`, gains `authors`); edition-2024 fmt/clippy fixes |
| `crates/edgezero-adapter-{fastly,cloudflare,spin,axum}/` | Inherit all five keys; delete the four duplicate env-guard implementations in favor of `edgezero_core::test_env` |
| `crates/edgezero-cli/` | Drop hardcoded `version` / `edition`, add missing `authors`; delete the fifth duplicate env guard (`test_support.rs`) |
| All 20 `[package]` sections | Add `description` to the 18 that lacked one; normalize key order |
| `examples/app-demo/Cargo.toml` + its 6 crates | `[workspace.package]` defined only `license`; now defines all five plus `edition = "2024"`, and the 6 crates inherit them |
| `examples/app-demo/Cargo.lock` | Refreshed (picks up the `toml_edit` bump already on `main`) |
| `crates/edgezero-cli/src/templates/root/Cargo.toml.hbs` | Generated root manifest had no `[workspace.package]`; now emits one with `edition = "2024"`, `publish = false`, and `authors = []` / `license = "Apache-2.0"` as user-editable placeholders |
| 6 generated crate templates (`cli`, `core`, and the 4 adapter `Cargo.toml.hbs`) | Inherit the five keys; add a name-derived `description` |
| `crates/edgezero-cli/src/templates/core/src/handlers.rs.hbs` | Generated handler tests use the shared `test-utils` guards instead of a hand-rolled env guard that would not compile under edition 2024 |
| `CLAUDE.md` | Edition 2021 → 2024 |

## Closes

Closes #321

## Test plan

- [x] `cargo test --workspace --all-targets` — pass, 0 failures
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — pass
- [x] `cargo fmt --all -- --check` — pass
- [x] `cargo check --workspace --all-targets --features "fastly cloudflare spin"` — pass
- [x] WASM: `cargo check -p edgezero-adapter-spin --target wasm32-wasip2 --features spin` — pass
- [x] `examples/app-demo` workspace: `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` all pass
- [x] Other: `cargo metadata` on both workspaces resolves all 14 crates with the correct inherited values (version, edition `2024`, `Apache-2.0`, `publish = false`, `authors`, `description`)
- [x] Other: scaffolded a project with `edgezero new` — `cargo clippy -- -D warnings` passes, its 8 handler tests pass, and `cargo metadata` resolves it with the inherited values
- [x] Other: audited that the workspace contains exactly one `#[expect(unsafe_code)]` and that every `unsafe` block lives in `crates/edgezero-core/src/test_env.rs`

### Known limitation (pre-existing, not introduced here)

A freshly generated project's `cargo fmt --check` still reports one diff: the sort position of `use <proj>_core::config::...` relative to `use edgezero_cli::...` depends on whether the project name sorts before or after `"edgezero"`, so a static template cannot be correct for every project name. The template already hard-coded that import last before this PR; the edition change does not cause it. Worth a follow-up (e.g. running `cargo fmt` as part of `edgezero new`), but it is out of scope here.

## Checklist

- [x] Changes follow [CLAUDE.md](/CLAUDE.md) conventions
- [x] No Tokio deps added to core or adapter crates
- [x] Route params use `{id}` syntax (not `:id`) — n/a, no routing behavior touched
- [x] Types imported from `edgezero_core` (not `http` crate)
- [x] Store wiring goes through `KvRegistry` / `ConfigRegistry` / `SecretRegistry` — n/a
- [x] New code has tests — the new `test_env` module is exercised by the 34 migrated call sites across five crates; metadata changes verified via `cargo metadata` on both workspaces and a freshly scaffolded project
- [x] No secrets or credentials committed
