### PR TITLE
Fix rollback hint to reference a capture route that exists

### DIFF
--- a/crates/edgezero-cli/src/args.rs
+++ b/crates/edgezero-cli/src/args.rs
@@ -381,8 +381,9 @@ pub struct RollbackArgs {
     /// Production only: the version to re-activate. Fastly exposes no
     /// metadata to tell a previously-live version from a staged one, so
     /// the rollback target CANNOT be inferred; it is captured before the
-    /// deploy that superseded it (see `deploy`'s `previous-version`) and
-    /// passed here. Required for a production rollback; ignored for staging.
+    /// deploy that superseded it (`active-version`, or the deploy-fastly
+    /// action's `previous-version` output) and passed here. Required for
+    /// a production rollback; ignored for staging.
     #[arg(long)]
     pub rollback_to: Option<String>,
     /// Platform service id to roll back. Required.

--- a/crates/edgezero-cli/src/lib.rs
+++ b/crates/edgezero-cli/src/lib.rs
@@ -516,8 +516,9 @@ pub fn run_rollback(args: &RollbackArgs) -> Result<(), String> {
         return Err(
             "a production rollback requires --rollback-to (the version to re-activate). Fastly \
              exposes no metadata to infer it, so it must be captured before the deploy that \
-             superseded it -- use `deploy`'s `previous-version` output. Pass --staging to \
-             deactivate a staged version instead."
+             superseded it -- run `active-version` before deploying (the deploy-fastly GitHub \
+             action does this and exposes it as its `previous-version` output). Pass --staging \
+             to deactivate a staged version instead."
                 .to_owned(),
         );
     }


### PR DESCRIPTION
## Problem

Addresses #350. The `run_rollback` missing-target error told operators to use `deploy`'s `previous-version` output, but no such output exists: the CLI's production deploy emits only `version=<N>`. `previous-version` is produced one layer up, by the `deploy-fastly` GitHub action's `capture-previous.sh`, which runs `active-version` before deploying. An operator following the hint mid-incident found nothing to use.

## Change

Reword the hint in `run_rollback` and the matching `--rollback-to` doc comment in `RollbackArgs` to name the capture routes that actually exist: run `active-version` before deploying, or wire the `deploy-fastly` action's `previous-version` output. Two strings, no behavior change. The docs site already attributes `previous-version` to the action correctly, so it needs no edit.

## Why not option 1 (emit `previous-version` from the CLI deploy)

The production deploy resolves its version from the deploy command's own output first, with the Fastly API only as a fallback, deliberately so manifest `deploy` command overrides (including test fixtures with dummy credentials) work without API access. Capturing the previous version can only happen via a pre-deploy API call, so option 1 either makes that call mandatory (breaking the override path and adding a new failure mode to every production deploy) or tolerates capture failure (emitting a line scripts cannot rely on, which is worse than no line). The action layer already captures the target fail-closed at the right place; the CLI hint just needs to tell the truth.

## Verification

- `cargo fmt -p edgezero-cli -- --check` passes
- `cargo clippy -p edgezero-cli --all-targets --all-features -- -D warnings` passes
- `cargo test -p edgezero-cli` passes
- `git grep previous-version crates/` shows only the corrected references; no test pins the old hint text

Closes #350